### PR TITLE
Only build a package if it is an upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,8 @@ jobs:
       run: |
         chown -R build:build ${{ matrix.package }}
         cd ${{ matrix.package }}
+        sudo -u build PATH=${PATH} PSPDEV=${PSPDEV} ${PSPDEV}/bin/psp-pacman -Swdd --noconfirm ${{ matrix.package }} && \
+        sudo -u build PSPDEV=${PSPDEV} cp -v ${PSPDEV}/var/cache/pacman/pkg/${{ matrix.package }}-*.pkg.tar.gz ./ || true
         sudo -u build PATH=${PATH} PSPDEV=${PSPDEV} ${PSPDEV}/bin/psp-makepkg -i --noconfirm
         cd ..
     - name: Store package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
       run: |
         chown -R build:build ${{ matrix.package }}
         cd ${{ matrix.package }}
-        sudo -u build PATH=${PATH} PSPDEV=${PSPDEV} ${PSPDEV}/bin/psp-pacman -Swdd --noconfirm ${{ matrix.package }} && \
+        sudo -u build PATH=${PATH} PSPDEV=${PSPDEV} ${PSPDEV}/bin/psp-pacman -Sywdd --noconfirm ${{ matrix.package }} && \
         sudo -u build PSPDEV=${PSPDEV} cp -v ${PSPDEV}/var/cache/pacman/pkg/${{ matrix.package }}-*.pkg.tar.gz ./ || true
         sudo -u build PATH=${PATH} PSPDEV=${PSPDEV} ${PSPDEV}/bin/psp-makepkg -i --noconfirm
         cd ..
@@ -72,6 +72,8 @@ jobs:
         for f in ${{ matrix.package }}; do
         chown -R build:build $f
         cd $f
+        sudo -u build PATH=${PATH} PSPDEV=${PSPDEV} ${PSPDEV}/bin/psp-pacman -Sywdd --noconfirm $f && \
+        sudo -u build PSPDEV=${PSPDEV} cp -v ${PSPDEV}/var/cache/pacman/pkg/$f-*.pkg.tar.gz ./ || true
         sudo -u build PATH=${PATH} PSPDEV=${PSPDEV} ${PSPDEV}/bin/psp-makepkg -i --noconfirm
         cd ..
         done


### PR DESCRIPTION
Rebuilding every package every time is a bit costly and it causes some issues with checksums. If you reinstall a package after a repo update, you will probably see an error at the moment. This PR is made to address this, but it's not yet ready.

This PR makes it so packages are downloaded from the repo before being build. This makes it so if there is no version change, the package will not be build at all and the existing package will be added to the new release.