### PR TITLE
Disable loongson manually since autodetect seems to fail for allegrex

### DIFF
--- a/pixman/PSPBUILD
+++ b/pixman/PSPBUILD
@@ -16,7 +16,7 @@ build() {
     ./autogen.sh
     LDFLAGS="-L$(psp-config --pspsdk-path)/lib $(psp-pkgconf --libs libpng zlib)" \
     CFLAGS="-G0 -O2 $(psp-pkgconf --cflags libpng zlib)" \
-    ./configure --host=psp --prefix=/psp
+    ./configure --disable-loongson-mmi --host=psp --prefix=/psp
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 


### PR DESCRIPTION
Seems that newer versions of binutils make this test fail somehow.
(Even though I cannot reproduce this locally with either toolchain version!)