### PR TITLE
Don't check dependencies when installing artifacts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -73,7 +73,7 @@ jobs:
         adduser -D -h /build -s /bin/bash build
         chown -R build:build /build ${PSPDEV} package
         cd package
-        sudo -u build PATH=${PATH} PSPDEV=${PSPDEV} ${PSPDEV}/bin/psp-pacman -U --noconfirm *.pkg.tar.gz --overwrite '*'
+        sudo -u build PATH=${PATH} PSPDEV=${PSPDEV} ${PSPDEV}/bin/psp-pacman -Udd --noconfirm *.pkg.tar.gz --overwrite '*'
         cd ..
     - name: Build packages
       run: |


### PR DESCRIPTION
This is currently causing issues randomly. We have no system in place which guarantees that all dependencies are available for all artifacts in the build_depends stage of the build process. With this change, this should no longer matter. This solution works, because the packages which have this issue are never needed to build the current package.