### PR TITLE
Patch zlib cmake and ensure we only build one library (static)

### DIFF
--- a/zlib/PSPBUILD
+++ b/zlib/PSPBUILD
@@ -9,8 +9,15 @@ license=('ZLIB')
 depends=()
 makedepends=()
 optdepends=()
-source=("https://github.com/madler/zlib/archive/v${pkgver}.tar.gz")
-sha256sums=('629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff')
+source=("https://github.com/madler/zlib/archive/v${pkgver}.tar.gz"
+        "cmake.patch")
+sha256sums=('629380c90a77b964d896ed37163f5c3a34f6e6d897311f1df2a7016355c45eff'
+            'SKIP')
+
+prepare() {
+    cd "${pkgname}-${pkgver}"
+    patch -p1 < ../cmake.patch
+}
 
 build() {
     cd "${pkgname}-${pkgver}"

--- a/zlib/cmake.patch
+++ b/zlib/cmake.patch
@@ -1,0 +1,62 @@
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -183,10 +183,13 @@
+     set(ZLIB_DLL_SRCS ${CMAKE_CURRENT_BINARY_DIR}/zlib1rc.obj)
+ endif(MINGW)
+ 
+-add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
+ add_library(zlibstatic STATIC ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
+-set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
+-set_target_properties(zlib PROPERTIES SOVERSION 1)
++set_target_properties(zlibstatic PROPERTIES OUTPUT_NAME z)
++
++if(BUILD_SHARED_LIBS)
++  add_library(zlib SHARED ${ZLIB_SRCS} ${ZLIB_ASMS} ${ZLIB_DLL_SRCS} ${ZLIB_PUBLIC_HDRS} ${ZLIB_PRIVATE_HDRS})
++  set_target_properties(zlib PROPERTIES DEFINE_SYMBOL ZLIB_DLL)
++  set_target_properties(zlib PROPERTIES SOVERSION 1)
+ 
+ if(NOT CYGWIN)
+     # This property causes shared libraries on Linux to have the full version
+@@ -201,7 +204,7 @@
+ 
+ if(UNIX)
+     # On unix-like platforms the library is almost always called libz
+-   set_target_properties(zlib zlibstatic PROPERTIES OUTPUT_NAME z)
++   set_target_properties(zlib PROPERTIES OUTPUT_NAME z)
+    if(NOT APPLE)
+      set_target_properties(zlib PROPERTIES LINK_FLAGS "-Wl,--version-script,\"${CMAKE_CURRENT_SOURCE_DIR}/zlib.map\"")
+    endif()
+@@ -210,11 +213,20 @@
+     set_target_properties(zlib PROPERTIES SUFFIX "1.dll")
+ endif()
+ 
++endif()
++
+ if(NOT SKIP_INSTALL_LIBRARIES AND NOT SKIP_INSTALL_ALL )
++  if(BUILD_SHARED_LIBS)
+     install(TARGETS zlib zlibstatic
+         RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
+         ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
+         LIBRARY DESTINATION "${INSTALL_LIB_DIR}" )
++  else()
++    install(TARGETS zlibstatic
++        RUNTIME DESTINATION "${INSTALL_BIN_DIR}"
++        ARCHIVE DESTINATION "${INSTALL_LIB_DIR}"
++        LIBRARY DESTINATION "${INSTALL_LIB_DIR}" )
++  endif()
+ endif()
+ if(NOT SKIP_INSTALL_HEADERS AND NOT SKIP_INSTALL_ALL )
+     install(FILES ${ZLIB_PUBLIC_HDRS} DESTINATION "${INSTALL_INC_DIR}")
+@@ -230,6 +242,7 @@
+ # Example binaries
+ #============================================================================
+ 
++if(BUILD_CLIS)
+ add_executable(example test/example.c)
+ target_link_libraries(example zlib)
+ add_test(example example)
+@@ -247,3 +260,4 @@
+     target_link_libraries(minigzip64 zlib)
+     set_target_properties(minigzip64 PROPERTIES COMPILE_FLAGS "-D_FILE_OFFSET_BITS=64")
+ endif()
++endif()


### PR DESCRIPTION
Building two of them seems to cause some race conditions on multithread builds (particularly on the CI)
Tested locally :)