### PR TITLE
Fix libpspvram build when using multiple jobs

### DIFF
--- a/libpspvram/PSPBUILD
+++ b/libpspvram/PSPBUILD
@@ -20,7 +20,7 @@ pkgver() {
 
 build() {
     cd "$pkgname"
-    make
+    make -j1
 }
 
 package() {


### PR DESCRIPTION
As I'm only fixing the build process, I didn't modify the pkgrel field.