### PR TITLE
Make libxmp only build the static library

### DIFF
--- a/libxmp/PSPBUILD
+++ b/libxmp/PSPBUILD
@@ -15,7 +15,7 @@ build() {
     cd "$pkgname"
     mkdir -p build
     cd build
-    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
+    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED=OFF \
         "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }


### PR DESCRIPTION
This fixes the occasional failures we are seeing.