### PR TITLE
Use pixman's release package instead of git

### DIFF
--- a/pixman/PSPBUILD
+++ b/pixman/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=pixman
 pkgver=0.40.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Pixman is a low-level software library for pixel manipulation"
 arch=('mips')
 url="http://pixman.org/"
@@ -8,12 +8,12 @@ license=('MIT')
 depends=('libpng')
 makedepends=()
 optdepends=()
-source=("https://github.com/freedesktop/pixman/archive/${pkgname}-${pkgver}.tar.gz")
-sha256sums=('3a68a28318a78fffc61603c8385bb0010c3fb23d17cd1285d36a7148c87a3b91')
+source=("https://xorg.freedesktop.org/archive/individual/lib/${pkgname}-${pkgver}.tar.gz")
+sha256sums=('6d200dec3740d9ec4ec8d1180e25779c00bc749f94278c8b9021f5534db223fc')
 
 build() {
-    cd "$pkgname-$pkgname-${pkgver}"
-    ./autogen.sh
+    cd "${pkgname}-${pkgver}"
+    autoreconf -if
     LDFLAGS="-L$(psp-config --pspsdk-path)/lib $(psp-pkgconf --libs libpng zlib)" \
     CFLAGS="-G0 -O2 $(psp-pkgconf --cflags libpng zlib)" \
     ./configure --disable-loongson-mmi --host=psp --prefix=/psp
@@ -21,7 +21,7 @@ build() {
 }
 
 package() {
-    cd "$pkgname-$pkgname-${pkgver}"
+    cd "${pkgname}-${pkgver}"
     make --quiet $MAKEFLAGS DESTDIR="$pkgdir/" install || { exit 1; }
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"


### PR DESCRIPTION
Fixes the non-standard directory naming. Also removes the usage of
autogen.sh script, which seems to cause some issues on mismatching
autoreconf versions.
Most distros seem to use the freedesktop release archive too.