### PR TITLE
Make sure pkg-config is available

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Install dependencies
       run: |
         apk add build-base bash acl sudo fakeroot curl patch gpgme-dev libarchive-tools libarchive-dev \
-          openssl-dev git bison autoconf automake tcl-dev libtool cmake doxygen texinfo flex
+          openssl-dev git bison autoconf automake tcl-dev libtool cmake doxygen texinfo flex pkgconf
     - name: Build package
       run: |
         adduser -D -h /build -s /bin/bash build
@@ -67,7 +67,7 @@ jobs:
     - name: Install dependencies
       run: |
         apk add build-base bash acl sudo fakeroot curl patch gpgme-dev libarchive-tools libarchive-dev \
-          openssl-dev git bison autoconf automake tcl-dev libtool cmake doxygen texinfo flex
+          openssl-dev git bison autoconf automake tcl-dev libtool cmake doxygen texinfo flex pkgconf
     - name: Install package
       run: |
         adduser -D -h /build -s /bin/bash build


### PR DESCRIPTION
Without this change it will not be possible to use pkg-config in build scripts, since pkg-config is no longer bundled and the wrapper script uses it.