### PR TITLE
Use upstream SDL2

### DIFF
--- a/sdl2/PSPBUILD
+++ b/sdl2/PSPBUILD
@@ -1,32 +1,37 @@
 pkgname=sdl2
-pkgver=2.0.14
-pkgrel=5
+pkgver=2.0.19
+pkgrel=1
 pkgdesc="a library designed to provide low level access to audio, input, and graphics hardware"
 arch=('mips')
-url="https://github.com/pspdev/SDL"
+url="https://github.com/libsdl-org/SDL"
 license=('ZLIB')
 depends=('libpspvram' 'pspgl')
 makedepends=()
 optdepends=()
 provides=('sdl2-main')
-source=("git+https://github.com/fjtrujy/SDL.git#commit=43c7064661fd01a3c434b67105c65205fff8b4b6")
+source=("git+https://github.com/libsdl-org/SDL.git#commit=e0c5399119afbd4543308212d2a461cb98abfa56")
 sha256sums=('SKIP')
+
+prepare() {
+    cd SDL
+    sed -i 's#@prefix@\|@exec_prefix@#${PSPDEV}/psp#' sdl2-config.in
+    sed -i 's#@libdir@#${PSPDEV}/psp/lib#' sdl2-config.in
+    sed -i 's#@includedir@#${PSPDEV}/psp/include#' sdl2-config.in
+}
 
 build() {
     cd SDL
-    make -f Makefile.psp
-    make -f Makefile.main.psp
+    mkdir -p build
+    cd build
+    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
+    make --quiet $MAKEFLAGS || { exit 1; }
 }
 
 package() {
-    cd SDL
-    mkdir -m 755 -p "$pkgdir/psp/lib" 
-    install -m 644 "libSDL2.a" "libSDL2main.a" "$pkgdir/psp/lib"
-
-    mkdir -m 755 -p "$pkgdir/psp/include/SDL2"
-    cp -v include/*.h "$pkgdir/psp/include/SDL2"
+    cd SDL/build
+    make --quiet $MAKEFLAGS install
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
-    install -m 644 COPYING.txt "$pkgdir/psp/share/licenses/$pkgname"
+    install -m 644 ../LICENSE.txt "$pkgdir/psp/share/licenses/$pkgname"
 }
 


### PR DESCRIPTION
Upstream SDL2 has been improved to the point where it is much better than the PSPDEV port. There are still some rendering issues in some rare cases, but those are also found in our old port. This is still the in development version, but there is no release with our changes yet.