### PR TITLE
Use latest upstream commit for sdl2

### DIFF
--- a/sdl2/PSPBUILD
+++ b/sdl2/PSPBUILD
@@ -1,5 +1,5 @@
 pkgname=sdl2
-pkgver=2.0.20
+pkgver=2.0.21
 pkgrel=1
 pkgdesc="a library designed to provide low level access to audio, input, and graphics hardware"
 arch=('mips')
@@ -9,18 +9,18 @@ depends=('libpspvram' 'pspgl')
 makedepends=()
 optdepends=()
 provides=('sdl2-main')
-source=("https://github.com/libsdl-org/SDL/archive/refs/tags/release-${pkgver}.tar.gz")
-sha256sums=('2a026753af9b03fca043824bca8341f74921a836d28729e0c31aa262202a83c6')
+source=("git+https://github.com/libsdl-org/SDL.git#commit=18032979d892639ad4e03584a40a4d205cd2f5fd")
+sha256sums=('SKIP')
 
 prepare() {
-    cd SDL-release-${pkgver}
+    cd SDL
     sed -i 's#@prefix@\|@exec_prefix@#${PSPDEV}/psp#' sdl2-config.in
     sed -i 's#@libdir@#${PSPDEV}/psp/lib#' sdl2-config.in
     sed -i 's#@includedir@#${PSPDEV}/psp/include#' sdl2-config.in
 }
 
 build() {
-    cd SDL-release-${pkgver}
+    cd SDL
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
@@ -28,7 +28,7 @@ build() {
 }
 
 package() {
-    cd SDL-release-${pkgver}/build
+    cd SDL/build
     make --quiet $MAKEFLAGS install
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"


### PR DESCRIPTION
3 bugs were fixed upstream for which there is no release yet:
- RenderCopyEx wasn't working (https://github.com/libsdl-org/SDL/pull/5335)
- RenderDrawRect was only drawing the top sides (https://github.com/libsdl-org/SDL/pull/5341)
- Streaming textures were being swizzled, causing rendering issues when updating them (https://github.com/libsdl-org/SDL/commit/66ee79bd68335b9725fd94defc3e5ac5ff3c4249)

I think these fixes are important enough to not wait for the next
release.