### PR TITLE
Update sqlite to 3.7.4 with different mirror

### DIFF
--- a/sqlite/PSPBUILD
+++ b/sqlite/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=sqlite
-pkgver=3.7.3
-pkgrel=4
+pkgver=3.7.4
+pkgrel=1
 pkgdesc="SQLite is a C-language library that implements a small, fast, self-contained, high-reliability, full-featured, SQL database engine"
 arch=('mips')
 url="https://www.sqlite.org/"
@@ -9,21 +9,21 @@ depends=()
 optdepends=()
 makedepends=()
 source=(
-    "https://www.sqlite.org/src/tarball/26778480/SQLite-26778480.tar.gz"
+    "https://github.com/sqlite/sqlite/archive/refs/tags/version-3.7.4.tar.gz"
     "${pkgname}-${pkgver}-PSP.patch"
 )
 sha256sums=(
-    "bb49ad9c7d0e10f9c0862fdfc57dd6bfe5164b478a464179f3d34ca847a46dc6"
+    "5fdbe958102f6f9dc93f3fc2f9e61a327fe8067fed227cd63ae26ed210a2774a"
     "SKIP"
 )
 
 prepare() {
-    cd "SQLite-26778480"
+    cd "${pkgname}-version-${pkgver}"
     patch -p1 < ../${pkgname}-${pkgver}-PSP.patch
 }
 
 build() {
-    cd "SQLite-26778480"
+    cd "${pkgname}-version-${pkgver}"
     LDFLAGS="-L$(psp-config --pspsdk-path)/lib -lc -lpspuser" \
     CFLAGS="-G0 -O2 -DSQLITE_OS_OTHER=1 -DSQLITE_OS_PSP=1 -I$(psp-config --pspsdk-path)/include" \
     ./configure --host=psp --prefix="/psp" --disable-readline --disable-tcl --disable-threadsafe --disable-amalgamation
@@ -31,7 +31,7 @@ build() {
 }
 
 package() {
-    cd "SQLite-26778480"
+    cd "${pkgname}-version-${pkgver}"
     make DESTDIR="$pkgdir" install
 
     rm "${pkgdir}/psp/lib/libsqlite3.la"

--- a/sqlite/sqlite-3.7.4-PSP.patch
+++ b/sqlite/sqlite-3.7.4-PSP.patch
@@ -1,21 +1,8 @@
-diff -urN sqlite-3.7.3-orig/config.sub sqlite-3.7.3-psp/config.sub
---- sqlite-3.7.3-orig/config.sub	2010-10-01 22:19:27.000000000 +0200
-+++ sqlite-3.7.3-psp/config.sub	2010-12-28 13:24:15.000000000 +0100
-@@ -898,6 +898,10 @@
- 	ps2)
- 		basic_machine=i386-ibm
- 		;;
-+	psp)
-+	    basic_machine=mipsallegrexel-psp
-+	    os=-elf
-+	    ;;
- 	pw32)
- 		basic_machine=i586-unknown
- 		os=-pw32
-diff -urN sqlite-3.7.3-orig/Makefile.in sqlite-3.7.3-psp/Makefile.in
---- sqlite-3.7.3-orig/Makefile.in	2010-10-07 16:48:41.000000000 +0200
-+++ sqlite-3.7.3-psp/Makefile.in	2010-12-28 13:28:55.000000000 +0100
-@@ -175,13 +175,13 @@
+diff --git a/Makefile.in b/Makefile.in
+index d5e29a1..7d442e2 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -176,7 +176,7 @@ LIBOBJS0 = alter.lo analyze.lo attach.lo auth.lo \
           main.lo malloc.lo mem0.lo mem1.lo mem2.lo mem3.lo mem5.lo \
           memjournal.lo \
           mutex.lo mutex_noop.lo mutex_os2.lo mutex_unix.lo mutex_w32.lo \
@@ -24,14 +11,7 @@ diff -urN sqlite-3.7.3-orig/Makefile.in sqlite-3.7.3-psp/Makefile.in
           pager.lo parse.lo pcache.lo pcache1.lo pragma.lo prepare.lo printf.lo \
           random.lo resolve.lo rowset.lo rtree.lo select.lo status.lo \
           table.lo tokenize.lo trigger.lo \
-          update.lo util.lo vacuum.lo \
-          vdbe.lo vdbeapi.lo vdbeaux.lo vdbeblob.lo vdbemem.lo vdbetrace.lo \
--         wal.lo walker.lo where.lo utf.o vtab.lo
-+         wal.lo walker.lo where.lo utf.lo vtab.lo
- 
- # Object files for the amalgamation.
- #
-@@ -242,6 +242,7 @@
+@@ -243,6 +243,7 @@ SRC = \
    $(TOP)/src/os.h \
    $(TOP)/src/os_common.h \
    $(TOP)/src/os_os2.c \
@@ -39,7 +19,7 @@ diff -urN sqlite-3.7.3-orig/Makefile.in sqlite-3.7.3-psp/Makefile.in
    $(TOP)/src/os_unix.c \
    $(TOP)/src/os_win.c \
    $(TOP)/src/pager.c \
-@@ -468,7 +469,7 @@
+@@ -471,7 +472,7 @@ EXTHDR += \
  # This is the default Makefile target.  The objects listed here
  # are what get build when you type just "make" with no arguments.
  #
@@ -48,7 +28,7 @@ diff -urN sqlite-3.7.3-orig/Makefile.in sqlite-3.7.3-psp/Makefile.in
  
  Makefile: $(TOP)/Makefile.in
  	./config.status
-@@ -670,6 +671,9 @@
+@@ -673,6 +674,9 @@ os_win.lo:	$(TOP)/src/os_win.c $(HDR)
  os_os2.lo:	$(TOP)/src/os_os2.c $(HDR)
  	$(LTCOMPILE) $(TEMP_STORE) -c $(TOP)/src/os_os2.c
  
@@ -58,7 +38,7 @@ diff -urN sqlite-3.7.3-orig/Makefile.in sqlite-3.7.3-psp/Makefile.in
  pragma.lo:	$(TOP)/src/pragma.c $(HDR)
  	$(LTCOMPILE) $(TEMP_STORE) -c $(TOP)/src/pragma.c
  
-@@ -886,10 +890,12 @@
+@@ -889,10 +893,12 @@ sqlite3_analyzer$(TEXE):	$(TESTFIXTURE_SRC) $(TOP)/tool/spaceanal.tcl
  lib_install:	libsqlite3.la
  	$(INSTALL) -d $(DESTDIR)$(libdir)
  	$(LTINSTALL) libsqlite3.la $(DESTDIR)$(libdir)
@@ -68,16 +48,18 @@ diff -urN sqlite-3.7.3-orig/Makefile.in sqlite-3.7.3-psp/Makefile.in
 +exe_install:    sqlite3$(BEXE)
  	$(INSTALL) -d $(DESTDIR)$(bindir)
  	$(LTINSTALL) sqlite3$(BEXE) $(DESTDIR)$(bindir)
-+	
++
 +install:        $(SQLITE_OS_PSP:0=exe_install) lib_install sqlite3.h sqlite3.pc ${HAVE_TCL:1=tcl_install}
  	$(INSTALL) -d $(DESTDIR)$(includedir)
  	$(INSTALL) -m 0644 sqlite3.h $(DESTDIR)$(includedir)
  	$(INSTALL) -m 0644 $(TOP)/src/sqlite3ext.h $(DESTDIR)$(includedir)
-diff -urN sqlite-3.7.3-orig/README.PSP sqlite-3.7.3-psp/README.PSP
---- sqlite-3.7.3-orig/README.PSP	1970-01-01 01:00:00.000000000 +0100
-+++ sqlite-3.7.3-psp/README.PSP	2010-12-28 13:26:32.000000000 +0100
+diff --git a/README.PSP b/README.PSP
+new file mode 100644
+index 0000000..5959e5c
+--- /dev/null
++++ b/README.PSP
 @@ -0,0 +1,35 @@
-+SQLite 3.7.3 port for Sony PSP
++SQLite 3.7.4 port for Sony PSP
 +==============================
 +    original port by
 +    	Nicolas R. <nikolas.robin@gmail.com>
@@ -112,9 +94,26 @@ diff -urN sqlite-3.7.3-orig/README.PSP sqlite-3.7.3-psp/README.PSP
 +Building applications
 +---------------------
 +Link your application with "-lsqlite3"
-diff -urN sqlite-3.7.3-orig/src/os_psp.c sqlite-3.7.3-psp/src/os_psp.c
---- sqlite-3.7.3-orig/src/os_psp.c	1970-01-01 01:00:00.000000000 +0100
-+++ sqlite-3.7.3-psp/src/os_psp.c	2010-12-28 13:23:04.000000000 +0100
+diff --git a/config.sub b/config.sub
+index 63cdd0a..a4ec3c2 100644
+--- a/config.sub
++++ b/config.sub
+@@ -898,6 +898,10 @@ case $basic_machine in
+ 	ps2)
+ 		basic_machine=i386-ibm
+ 		;;
++	psp)
++	    basic_machine=mipsallegrexel-psp
++	    os=-elf
++	    ;;
+ 	pw32)
+ 		basic_machine=i586-unknown
+ 		os=-pw32
+diff --git a/src/os_psp.c b/src/os_psp.c
+new file mode 100644
+index 0000000..3c3f97d
+--- /dev/null
++++ b/src/os_psp.c
 @@ -0,0 +1,689 @@
 +/*
 +** 2010 Nov 01
@@ -805,9 +804,10 @@ diff -urN sqlite-3.7.3-orig/src/os_psp.c sqlite-3.7.3-psp/src/os_psp.c
 +}
 +
 +#endif /* SQLITE_OS_PSP */
-diff -urN sqlite-3.7.3-orig/src/printf.c sqlite-3.7.3-psp/src/printf.c
---- sqlite-3.7.3-orig/src/printf.c	2010-10-02 03:23:23.000000000 +0200
-+++ sqlite-3.7.3-psp/src/printf.c	2010-12-28 13:23:18.000000000 +0100
+diff --git a/src/printf.c b/src/printf.c
+index da2fdf6..6ea5830 100644
+--- a/src/printf.c
++++ b/src/printf.c
 @@ -52,6 +52,10 @@
  */
  #include "sqliteInt.h"
@@ -819,7 +819,7 @@ diff -urN sqlite-3.7.3-orig/src/printf.c sqlite-3.7.3-psp/src/printf.c
  /*
  ** Conversion types fall into various categories as defined by the
  ** following enumeration.
-@@ -1000,8 +1004,13 @@
+@@ -1000,8 +1004,13 @@ void sqlite3DebugPrintf(const char *zFormat, ...){
    sqlite3VXPrintf(&acc, 0, zFormat, ap);
    va_end(ap);
    sqlite3StrAccumFinish(&acc);
@@ -833,9 +833,10 @@ diff -urN sqlite-3.7.3-orig/src/printf.c sqlite-3.7.3-psp/src/printf.c
  }
  #endif
  
-diff -urN sqlite-3.7.3-orig/src/sqliteInt.h sqlite-3.7.3-psp/src/sqliteInt.h
---- sqlite-3.7.3-orig/src/sqliteInt.h	2010-10-07 16:48:42.000000000 +0200
-+++ sqlite-3.7.3-psp/src/sqliteInt.h	2010-12-28 13:23:41.000000000 +0100
+diff --git a/src/sqliteInt.h b/src/sqliteInt.h
+index 4f0e08e..f70206b 100644
+--- a/src/sqliteInt.h
++++ b/src/sqliteInt.h
 @@ -429,12 +429,18 @@
  #ifndef LONGDOUBLE_TYPE
  # define LONGDOUBLE_TYPE long double


### PR DESCRIPTION
The tarball on the sqlite website was constantly changing, which is
totally unacceptable. The tag on the github should not change. I had to
adjust the patch a little bit to work with the next version, though. I
hope it works like expected, but I don't have an application I can test
this with.