### PR TITLE
Fix PC file in sdl2-ttf and remove workaround

### DIFF
--- a/freetype2/PSPBUILD
+++ b/freetype2/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=freetype2
 pkgver=2.11.0
-pkgrel=1
+pkgrel=2
 pkgdesc="a freely available software library to render fonts"
 arch=('mips')
 url="https://www.freetype.org/"
@@ -16,14 +16,14 @@ build() {
     cd "freetype-VER-${pkgver//./-}"
     mkdir -p build
     cd build
-    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
+    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=/psp -DBUILD_SHARED_LIBS=OFF \
         "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 
 package() {
     cd "freetype-VER-${pkgver//./-}/build"
-    make --quiet $MAKEFLAGS install
+    make --quiet DESTDIR=$pkgdir $MAKEFLAGS install
     cd ..
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"

--- a/libpng/PSPBUILD
+++ b/libpng/PSPBUILD
@@ -22,14 +22,14 @@ build() {
     cd "$pkgname-${pkgver}"
     mkdir -p build
     cd build
-    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
+    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=/psp -DBUILD_SHARED_LIBS=OFF \
         -DPNG_SHARED=OFF -DPNG_STATIC=ON "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 
 package() {
     cd "$pkgname-${pkgver}/build"
-    make --quiet $MAKEFLAGS install
+    make --quiet DESTDIR=$pkgdir $MAKEFLAGS install
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
     install -m 644 ../LICENSE "$pkgdir/psp/share/licenses/$pkgname"

--- a/sdl2-ttf/PSPBUILD
+++ b/sdl2-ttf/PSPBUILD
@@ -1,5 +1,5 @@
 pkgname=sdl2-ttf
-pkgver=2.0.18
+pkgver=2.0.19
 pkgrel=1
 pkgdesc="a companion library to SDL2 for working with TrueType (tm) fonts"
 arch=('mips')
@@ -8,26 +8,21 @@ license=('MIT')
 depends=('sdl2' 'freetype2')
 makedepends=()
 optdepends=()
-source=("https://github.com/libsdl-org/SDL_ttf/archive/refs/tags/release-${pkgver}.tar.gz")
-sha256sums=('6b61544441b72bdfa1ced89034c6396fe80228eff201eb72c5f78e500bb80bd0')
-
-prepare() {
-  cd "SDL_ttf-release-$pkgver"
-  sed -i '/POSITION_INDEPENDENT_CODE ON/d' CMakeLists.txt
-}
+source=("git+https://github.com/libsdl-org/SDL_ttf.git#commit=443fb12a8c9edde076beaa474071a3879a7829d3")
+sha256sums=('SKIP')
 
 build() {
-  cd "SDL_ttf-release-$pkgver"
+  cd "SDL_ttf"
   mkdir -p build
   cd build
-  cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
+  cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=/psp -DBUILD_SHARED_LIBS=OFF \
     "${XTRA_OPTS[@]}" .. || { exit 1; }
   make --quiet $MAKEFLAGS || { exit 1; }
 }
 
 package() {
-  cd "SDL_ttf-release-$pkgver/build"
-  make --quiet $MAKEFLAGS install
+  cd "SDL_ttf/build"
+  make --quiet DESTDIR=$pkgdir $MAKEFLAGS install
 
   mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
   install -m644 ../COPYING.txt "$pkgdir/psp/share/licenses/$pkgname"

--- a/sdl2-ttf/PSPBUILD
+++ b/sdl2-ttf/PSPBUILD
@@ -15,8 +15,8 @@ build() {
   cd "SDL_ttf"
   mkdir -p build
   cd build
-  cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=/psp -DBUILD_SHARED_LIBS=OFF \
-    "${XTRA_OPTS[@]}" .. || { exit 1; }
+  cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=/psp \
+    -DBUILD_SHARED_LIBS=OFF -DBUILD_SAMPLES=OFF -DVENDORED_DEFAULT=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
   make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/sdl2-ttf/PSPBUILD
+++ b/sdl2-ttf/PSPBUILD
@@ -8,7 +8,7 @@ license=('MIT')
 depends=('sdl2' 'freetype2')
 makedepends=()
 optdepends=()
-source=("git+https://github.com/libsdl-org/SDL_ttf.git#commit=443fb12a8c9edde076beaa474071a3879a7829d3")
+source=("git+https://github.com/libsdl-org/SDL_ttf.git#commit=e9dcda6d7a5a872d3d8c9ccdae10fdaf7f7e73a0")
 sha256sums=('SKIP')
 
 build() {

--- a/sdl2-ttf/PSPBUILD
+++ b/sdl2-ttf/PSPBUILD
@@ -24,7 +24,6 @@ package() {
   cd "SDL_ttf/build"
   make --quiet DESTDIR=$pkgdir $MAKEFLAGS install
 
-  mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
-  install -m644 ../COPYING.txt "$pkgdir/psp/share/licenses/$pkgname"
+  mv "$pkgdir/psp/share/licenses/SDL2_ttf" "$pkgdir/psp/share/licenses/$pkgname"
 }
 

--- a/sdl2/PSPBUILD
+++ b/sdl2/PSPBUILD
@@ -23,13 +23,13 @@ build() {
     cd SDL
     mkdir -p build
     cd build
-    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
+    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=/psp -DBUILD_SHARED_LIBS=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 
 package() {
     cd SDL/build
-    make --quiet $MAKEFLAGS install
+    make --quiet DESTDIR=$pkgdir $MAKEFLAGS install
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
     install -m 644 ../LICENSE.txt "$pkgdir/psp/share/licenses/$pkgname"

--- a/zlib/PSPBUILD
+++ b/zlib/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=zlib
 pkgver=1.2.11
-pkgrel=1
+pkgrel=2
 pkgdesc="Compression library implementing the deflate compression method found in gzip and PKZIP"
 arch=('mips')
 url="https://www.zlib.net/"
@@ -22,14 +22,14 @@ build() {
     cd "${pkgname}-${pkgver}"
     mkdir -p build
     cd build
-    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
+    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=/psp -DBUILD_SHARED_LIBS=OFF \
         -DUNIX:BOOL=ON "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 
 package() {
     cd "${pkgname}-${pkgver}/build"
-    make --quiet $MAKEFLAGS install || { exit 1; }
+    make --quiet DESTDIR=$pkgdir $MAKEFLAGS install || { exit 1; }
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
     install -m 644 ../README "$pkgdir/psp/share/licenses/$pkgname"


### PR DESCRIPTION
This uses a commit on git, but it does build. Now when using ``psp-pkg-config --libs SDL2_ttf`` it will return freetype2 as well. This makes it so all dependencies are returned by it.