### PR TITLE
Fix bzip2 and other minor improvements

### DIFF
--- a/bzip2/PSPBUILD
+++ b/bzip2/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=bzip2
 pkgver=1.0.8
-pkgrel=1
+pkgrel=2
 pkgdesc="A high-quality data compression library"
 arch=('mips')
 url="http://www.sourceware.org/bzip2/"

--- a/bzip2/PSPBUILD
+++ b/bzip2/PSPBUILD
@@ -8,7 +8,7 @@ license=('custom')
 depends=()
 makedepends=()
 optdepends=()
-source=("git+https://gitlab.com/fjtrujy/bzip2.git#commit=859485c930a678df80df4bbaf5aab22889d76683")
+source=("git+https://gitlab.com/bzip2/bzip2.git#commit=bf5f505d0156ad5c6635d05db06b1bb7593b45b7")
 sha256sums=('SKIP')
 
 build() {
@@ -16,7 +16,7 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
-        -DENABLE_SHARED_LIB=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DENABLE_SHARED_LIB=OFF -DENABLE_STATIC_LIB=ON -DENABLE_LIB_ONLY=ON "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 
@@ -27,5 +27,8 @@ package() {
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
     install -m 644 COPYING "$pkgdir/psp/share/licenses/$pkgname"
+
+    # The library gets built as libbz2_static.a, let's rename it since the default pkgconfig lib is obviously -lbz2
+    mv "$pkgdir/psp/lib/libbz2_static.a" "$pkgdir/psp/lib/libbz2.a"
 }
 

--- a/jpeg/PSPBUILD
+++ b/jpeg/PSPBUILD
@@ -27,5 +27,13 @@ package() {
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
     install -m 644 README.ijg "$pkgdir/psp/share/licenses/$pkgname"
+
+    # Build system produces a bunch of ELF binaries we never use, can't disable it, just delete them
+    rm -f "$pkgdir/psp/bin/tjbench"
+    rm -f "$pkgdir/psp/bin/cjpeg"
+    rm -f "$pkgdir/psp/bin/djpeg"
+    rm -f "$pkgdir/psp/bin/jpegtran"
+    rm -f "$pkgdir/psp/bin/rdjpgcom"
+    rm -f "$pkgdir/psp/bin/wrjpgcom"
 }
 

--- a/jpeg/PSPBUILD
+++ b/jpeg/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=jpeg
 pkgver=2.1.1
-pkgrel=1
+pkgrel=2
 pkgdesc="a free library for JPEG image compression"
 arch=('mips')
 url="https://ijg.org/"

--- a/zziplib/PSPBUILD
+++ b/zziplib/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=zziplib
 pkgver=0.13.72
-pkgrel=1
+pkgrel=2
 pkgdesc="provides read access to zipped files in a zip-archive"
 arch=('mips')
 url="http://zziplib.sourceforge.net/"

--- a/zziplib/PSPBUILD
+++ b/zziplib/PSPBUILD
@@ -16,7 +16,7 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
-        -DBUILD_STATIC_LIBS=ON -DZZIPSDL=OFF -DZZIPTEST=OFF -DZZIPDOCS=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DBUILD_STATIC_LIBS=ON -DZZIPSDL=OFF -DZZIPBINS=OFF -DZZIPTEST=OFF -DZZIPDOCS=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 


### PR DESCRIPTION
This fixes a few things with some packages.
bzip2 was broken for a while (the latest github release is missing the bzlib2 library), weird nobody noticed!