### PR TITLE
Add Eigen3

### DIFF
--- a/eigen3/PSPBUILD
+++ b/eigen3/PSPBUILD
@@ -15,7 +15,7 @@ build() {
   cd eigen-$pkgver
   mkdir build
   cd build
-  cmake .. -DCMAKE_TOOLCHAIN_FILE="$PSPDEV/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX="$PSPDEV/psp" -DCMAKE_BUILD_TYPE=Release -Wno-dev -DBUILD_SHARED_LIBS=OFF
+  cmake .. -DCMAKE_TOOLCHAIN_FILE="$PSPDEV/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX="/psp" -DCMAKE_BUILD_TYPE=Release -Wno-dev -DBUILD_SHARED_LIBS=OFF
   make $MAKEFLAGS || { exit 1; }
 }
 

--- a/eigen3/PSPBUILD
+++ b/eigen3/PSPBUILD
@@ -10,12 +10,16 @@ pkgdesc="C++ template library for linear algebra: matrices, vectors, numerical s
 arch=('mips')
 sha256sums=('8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72')
 
+prepare() {
+    cd "$srcdir/eigen-$pkgver"
+    sed -i 's#@CMAKE_INSTALL_PREFIX@#${PSPDEV}/psp#' eigen3.pc.in
+}
 
 build() {
   cd eigen-$pkgver
-  mkdir build
+  mkdir -p build
   cd build
-  cmake .. -DCMAKE_TOOLCHAIN_FILE="$PSPDEV/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX="/psp" -DCMAKE_BUILD_TYPE=Release -Wno-dev -DBUILD_SHARED_LIBS=OFF
+  cmake .. -DCMAKE_TOOLCHAIN_FILE="$PSPDEV/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX="/psp" -DCMAKE_BUILD_TYPE=Release -Wno-dev -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF
   make $MAKEFLAGS || { exit 1; }
 }
 
@@ -25,5 +29,9 @@ package() {
         make DESTDIR="$pkgdir" install
     )
 
-    install -Dm644 "$srcdir/eigen-$pkgver/COPYING.BSD" "$pkgdir/$PSPDEV/licenses/$pkgname/COPYING.BSD"
+	mkdir -p "$pkgdir/psp/lib/cmake"
+	mv "$pkgdir/psp/share/eigen3/cmake" "$pkgdir/psp/lib/cmake/eigen3"
+	rmdir "$pkgdir/psp/share/eigen3"
+
+    install -Dm644 "$srcdir/eigen-$pkgver/COPYING.BSD" "$pkgdir/psp/share/licenses/$pkgname/COPYING.BSD"
 }

--- a/eigen3/PSPBUILD
+++ b/eigen3/PSPBUILD
@@ -1,0 +1,29 @@
+pkgname=libeigen
+pkgver=3.4.0
+url="http://eigen.tuxfamily.org"
+source=("https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-$pkgver.tar.gz")
+license=('BSD')
+pkgrel=1
+depends=()
+makedepends=()
+pkgdesc="C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms"
+arch=('mips')
+sha256sums=('8586084f71f9bde545ee7fa6d00288b264a2b7ac3607b974e54d13e7162c1c72')
+
+
+build() {
+  cd eigen-$pkgver
+  mkdir build
+  cd build
+  cmake .. -DCMAKE_TOOLCHAIN_FILE="$PSPDEV/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX="$PSPDEV/psp" -DCMAKE_BUILD_TYPE=Release -Wno-dev -DBUILD_SHARED_LIBS=OFF
+  make $MAKEFLAGS || { exit 1; }
+}
+
+package() {
+    ( 
+        cd eigen-$pkgver/build
+        make install
+    )
+
+    install -Dm644 "$srcdir/eigen-$pkgver/COPYING.BSD" "$pkgdir/$PSPDEV/licenses/$pkgname/COPYING.BSD"
+}

--- a/eigen3/PSPBUILD
+++ b/eigen3/PSPBUILD
@@ -22,7 +22,7 @@ build() {
 package() {
     ( 
         cd eigen-$pkgver/build
-        make install
+        make DESTDIR="$pkgdir" install
     )
 
     install -Dm644 "$srcdir/eigen-$pkgver/COPYING.BSD" "$pkgdir/$PSPDEV/licenses/$pkgname/COPYING.BSD"


### PR DESCRIPTION
Eigen3 is an awesome C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms.

It is fully inline so there should not be any static or shared libraries required to link.

I would love to know how you would go about linking this one in a cmakelists.txt :D