### PR TITLE
Add polarSSL

### DIFF
--- a/polarssl/PSPBUILD
+++ b/polarssl/PSPBUILD
@@ -13,10 +13,10 @@ sha256sums=('d3605afc28ed4b7d1d9e3142d72e42855e4a23c07c951bbb0299556b02d36755')
 
 prepare() {
     cd "$pkgname-$pkgver"
-    sed '84s/.*/defined(PSP)/' library/net.c > library/net.c
-    sed '115s/.*/  /' include/polarssl/config.h > include/polarssl/config.h
-    sed '1974s/.*/ /' include/polarssl/config.h > include/polarssl/config.h
-    sed '28s/.*/set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${PSPDEV}/psp/sdk/include")/' CMakeLists.txt > CMakeLists.txt
+    sed -i '84s/.*/defined(PSP)/' library/net.c
+    sed -i '115s/.*/  /' include/polarssl/config.h
+    sed -i '1974s/.*/ /' include/polarssl/config.h
+    sed -i '28s/.*/set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${PSPDEV}\/psp\/sdk\/include")/' CMakeLists.txt
 }
 
 build() {

--- a/polarssl/PSPBUILD
+++ b/polarssl/PSPBUILD
@@ -1,0 +1,35 @@
+pkgname=polarssl
+pkgver=1.3.9
+pkgrel=1
+pkgdesc="Secure Socket Layer library"
+arch=('mips')
+url="https://www.trustedfirmware.org/projects/mbed-tls/"
+license=('GPL2 license')
+depends=()
+makedepends=()
+optdepends=()
+source=("https://src.fedoraproject.org/repo/pkgs/polarssl/polarssl-1.3.9-gpl.tgz/48af7d1f0d5de512cbd6dacf5407884c/$pkgname-$pkgver-gpl.tgz")
+sha256sums=('d3605afc28ed4b7d1d9e3142d72e42855e4a23c07c951bbb0299556b02d36755')
+
+prepare() {
+    cd "$pkgname-$pkgver"
+    sed '84s/.*/defined(PSP)/' library/net.c > library/net.c
+    sed '115s/.*/  /' include/polarssl/config.h > include/polarssl/config.h
+    sed '1974s/.*/ /' include/polarssl/config.h > include/polarssl/config.h
+    sed '28s/.*/set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -I${PSPDEV}/psp/sdk/include")/' CMakeLists.txt > CMakeLists.txt
+}
+
+build() {
+    cd "$pkgname-$pkgver"
+    mkdir -p build
+    cd build
+    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp \
+        -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTING=FALSE -DENABLE_PROGRAMS=FALSE "${XTRA_OPTS[@]}" .. || { exit 1; }
+    make --quiet $MAKEFLAGS || { exit 1; }
+}
+
+package() {
+    cd "$pkgname-$pkgver/build"
+    make --quiet $MAKEFLAGS install
+    cd ..
+}


### PR DESCRIPTION
This PR builds polarssl v1.3.9

note: I know that polarSSL has been replaced by mbedTLS, but I still use polarSSL for some projects (mostly for the hashing and crypto implementations).

