### PR TITLE
Install tar command for automated builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,7 @@ jobs:
     - uses: actions/checkout@v3
     - name: Install dependencies
       run: |
-        apk add build-base bash acl sudo fakeroot curl patch gpgme-dev libarchive-tools libarchive-dev xz \
+        apk add build-base bash tar acl sudo fakeroot curl patch gpgme-dev libarchive-tools libarchive-dev xz \
           openssl-dev git bison autoconf automake tcl-dev libtool cmake doxygen texinfo flex pkgconf libcrypto1.1
     - name: Build package
       run: |

--- a/argtable2/PSPBUILD
+++ b/argtable2/PSPBUILD
@@ -13,6 +13,7 @@ sha256sums=('8f77e8a7ced5301af6e22f47302fdbc3b1ff41f2b83c43c77ae5ca041771ddbf')
 
 
 build() {
+    ls -R
     cd "${pkgname}-${pkgver}"
     mkdir -p build
     cd build


### PR DESCRIPTION
It seems it's using gzip only right now, which should not happen.