### PR TITLE
Update sdl2 and all helper libraries

### DIFF
--- a/sdl2-image/PSPBUILD
+++ b/sdl2-image/PSPBUILD
@@ -1,5 +1,5 @@
 pkgname=sdl2-image
-pkgver=2.7.0
+pkgver=2.6.3
 pkgrel=1
 pkgdesc="a simple library to load images of various formats as SDL surfaces"
 arch=('mips')
@@ -8,27 +8,32 @@ license=('zlib')
 depends=('sdl2' 'libpng' 'jpeg')
 makedepends=()
 optdepends=()
-source=("git+https://github.com/libsdl-org/SDL_image#commit=ede6056d844e7a1ecec3e688cb4068d1ad0aa884")
-sha256sums=('SKIP')
-
+source=(
+    "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-${pkgver}.tar.gz"
+	"pkg-config-fix.patch"
+)
+sha256sums=(
+    "931c9be5bf1d7c8fae9b7dc157828b7eee874e23c7f24b44ba7eff6b4836312c"
+    "0adc4fbfbeb89b653a8050253d7bfa64a4ab3c54555879af68934168a978e16c"
+)
 prepare() {
-    cd "$srcdir/SDL_image"
-    sed -i 's#@prefix@#${PSPDEV}/psp#' SDL2_image.pc.in
+    cd "${srcdir}/SDL2_image-${pkgver}"
+    patch -Np1 -i "${srcdir}/pkg-config-fix.patch"
 }
 
 build() {
-    cd "$srcdir/SDL_image"
+    cd "${srcdir}/SDL2_image-${pkgver}"
     mkdir -p build && cd build
-    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=/psp \
-    -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=OFF -DSDL2IMAGE_DEPS_SHARED=OFF \
-    -DSDL2IMAGE_INSTALL=ON -DSDL2IMAGE_SAMPLES=OFF -DSDL2IMAGE_BACKEND_STB=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
+    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE="${PSPDEV}/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX=/psp \
+        -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=OFF -DSDL2IMAGE_DEPS_SHARED=OFF \
+        -DSDL2IMAGE_INSTALL=ON -DSDL2IMAGE_SAMPLES=OFF -DSDL2IMAGE_BACKEND_STB=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 
 package() {
-    cd "$srcdir/SDL_image/build"
-    make DESTDIR="$pkgdir" install
+    cd "${srcdir}/SDL2_image-${pkgver}/build"
+    make --quiet DESTDIR="${pkgdir}" ${MAKEFLAGS} install
 
-    mv "$pkgdir/psp/share/licenses/SDL2_image" "$pkgdir/psp/share/licenses/$pkgname"
+    mv "${pkgdir}/psp/share/licenses/SDL2_image" "${pkgdir}/psp/share/licenses/${pkgname}"
 }
 

--- a/sdl2-image/pkg-config-fix.patch
+++ b/sdl2-image/pkg-config-fix.patch
@@ -1,0 +1,42 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 438a0aa..934a330 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -694,8 +694,6 @@ if(SDL2IMAGE_INSTALL)
+         COMPONENT devel
+     )
+ 
+-    if(SDL2IMAGE_BUILD_SHARED_LIBS)
+-        # Only create a .pc file for a shared SDL2_image
+         set(prefix "${CMAKE_INSTALL_PREFIX}")
+         set(exec_prefix "\${prefix}")
+         set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+@@ -715,7 +713,7 @@ if(SDL2IMAGE_INSTALL)
+         else()
+             set(PC_DESTDIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+         endif()
+-        # Only install a SDL2_image.pc file in Release mode
++        # Always install SDL2_net.pc file: libraries might be different between config modes
+         install(CODE "
+             # FIXME: use file(COPY_FILE) if minimum CMake version >= 3.21
+             execute_process(COMMAND \"\${CMAKE_COMMAND}\" -E copy_if_different
+@@ -723,8 +721,7 @@ if(SDL2IMAGE_INSTALL)
+                 \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_image.pc\")
+             file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${PC_DESTDIR}\"
+                 TYPE FILE
+-                FILES \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_image.pc\")" CONFIG Release COMPONENT devel)
+-    endif()
++                FILES \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_image.pc\")" COMPONENT devel)
+ 
+     if(SDL2IMAGE_BUILD_SHARED_LIBS AND (APPLE OR (UNIX AND NOT ANDROID)))
+         install(
+diff --git a/SDL2_image.pc.in b/SDL2_image.pc.in
+index 8711dd7..cf6b501 100644
+--- a/SDL2_image.pc.in
++++ b/SDL2_image.pc.in
+@@ -1,4 +1,4 @@
+-prefix=@prefix@
++prefix=${PSPDEV}/psp
+ exec_prefix=@exec_prefix@
+ libdir=@libdir@
+ includedir=@includedir@

--- a/sdl2-mixer/PSPBUILD
+++ b/sdl2-mixer/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=sdl2-mixer
 pkgver=2.6.3
-pkgrel=2
+pkgrel=3
 pkgdesc="an audio mixer library based on the SDL2 library"
 arch=('mips')
 url="https://www.libsdl.org/projects/SDL_mixer/"
@@ -9,44 +9,44 @@ depends=('sdl2' 'libxmp' 'libvorbis' 'libogg')
 makedepends=()
 optdepends=()
 source=(
-    "git+https://github.com/libsdl-org/SDL_mixer#commit=c9f0946a783293d12178ce86773dd6f8f1a08b1c"
-    "main.c.sample"
+    "https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-${pkgver}.tar.gz"
+    "pkg-config-fix.patch"
     "CMakeLists.txt.sample"
+    "main.c.sample"
     "test.ogg.sample"
 )
 sha256sums=(
-    'SKIP'
-    'SKIP'
-    'SKIP'
-    'SKIP'
+    "7a6ba86a478648ce617e3a5e9277181bc67f7ce9876605eea6affd4a0d6eea8f"
+    "5cd916deff335df405df54fbcac9ad833e9ea69af38de104d87982e5161c07ca"
+    "de65e71e7fd1ef742f78f44fac404642f1c48f4bec227df6dee12b0b5b7f2cd0"
+    "02398828cf31287f3eff72baf605d05df6abf4b1b26d823fe30dff1469499c26"
+    "6e506fae57ce4700e6f0a05adc31a95e66840080f889e7df247c08df180fdcd8"
 )
 
 prepare() {
-    cd "$srcdir/SDL_mixer"
-    sed -i 's#@prefix@\|@exec_prefix@#${PSPDEV}/psp#' SDL2_mixer.pc.in
-    sed -i 's#@libdir@#${PSPDEV}/psp/lib#' SDL2_mixer.pc.in
-    sed -i 's#@includedir@#${PSPDEV}/psp/include#' SDL2_mixer.pc.in
+    cd "${srcdir}/SDL2_mixer-${pkgver}"
+    patch -Np1 -i "${srcdir}/pkg-config-fix.patch"
 }
 
 build() {
-    cd "$srcdir/SDL_mixer"
+    cd "${srcdir}/SDL2_mixer-${pkgver}"
     mkdir -p build && cd build
-    cmake -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
-          -DCMAKE_POSITION_INDEPENDENT_CODE=OFF -DSDL2MIXER_DEPS_SHARED=OFF -DSDL2MIXER_INSTALL=ON -DSDL2MIXER_SAMPLES=OFF \
-          -DSDL2MIXER_FLAC=OFF -DSDL2MIXER_OPUS=OFF -DSDL2MIXER_MIDI=OFF \
-          -DSDL2MIXER_VORBIS=VORBISFILE -DSDL2MIXER_VORBIS_VORBISFILE_SHARED=OFF \
-          -DSDL2MIXER_MOD=ON -DSDL2MIXER_MOD_MODPLUG=OFF -DSDL2MIXER_MOD_XMP=ON ..
-    make
+    cmake -DCMAKE_TOOLCHAIN_FILE="${PSPDEV}/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX=/psp \
+        -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=OFF -DSDL2MIXER_DEPS_SHARED=OFF \
+        -DSDL2MIXER_INSTALL=ON -DSDL2MIXER_SAMPLES=OFF -DSDL2MIXER_FLAC=OFF -DSDL2MIXER_OPUS=OFF \
+        -DSDL2MIXER_MIDI=OFF -DSDL2MIXER_VORBIS=VORBISFILE -DSDL2MIXER_VORBIS_VORBISFILE_SHARED=OFF \
+        -DSDL2MIXER_MOD=ON -DSDL2MIXER_MOD_MODPLUG=OFF -DSDL2MIXER_MOD_XMP=ON .. "${XTRA_OPTS[@]}" || { exit 1; }
+    make --quiet $MAKEFLAGS || { exit 1; }
 }
 
 package() {
-    mkdir -p "$pkgdir/psp/sdk/samples/sdl2/mixer/"
-    install -m 644 $srcdir/main.c.sample $pkgdir/psp/sdk/samples/sdl2/mixer/main.c
-    install -m 644 $srcdir/CMakeLists.txt.sample $pkgdir/psp/sdk/samples/sdl2/mixer/CMakeLists.txt
-    install -m 644 $srcdir/test.ogg.sample $pkgdir/psp/sdk/samples/sdl2/mixer/test.ogg
+    mkdir -p "${pkgdir}/psp/sdk/samples/sdl2/mixer/"
+    install -m 644 "${srcdir}/main.c.sample" "${pkgdir}/psp/sdk/samples/sdl2/mixer/main.c"
+    install -m 644 "${srcdir}/CMakeLists.txt.sample" "${pkgdir}/psp/sdk/samples/sdl2/mixer/CMakeLists.txt"
+    install -m 644 "${srcdir}/test.ogg.sample" "${pkgdir}/psp/sdk/samples/sdl2/mixer/test.ogg"
 
-    cd "$srcdir/SDL_mixer/build"
-    make --quiet $MAKEFLAGS install
+    cd "${srcdir}/SDL2_mixer-${pkgver}/build"
+    make --quiet DESTDIR="${pkgdir}" ${MAKEFLAGS} install
 
-    mv "$pkgdir/psp/share/licenses/SDL2_mixer" "$pkgdir/psp/share/licenses/$pkgname"
+    mv "${pkgdir}/psp/share/licenses/SDL2_mixer" "${pkgdir}/psp/share/licenses/${pkgname}"
 }

--- a/sdl2-mixer/pkg-config-fix.patch
+++ b/sdl2-mixer/pkg-config-fix.patch
@@ -1,0 +1,42 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 54317572..a066c586 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -796,8 +796,6 @@ if(SDL2MIXER_INSTALL)
+         COMPONENT devel
+     )
+ 
+-    if(SDL2MIXER_BUILD_SHARED_LIBS)
+-        # Only create a .pc file for a shared SDL2_mixer
+         set(VERSION ${FULL_VERSION})
+         set(SDL_VERSION ${SDL_REQUIRED_VERSION})
+         set(prefix "${CMAKE_INSTALL_PREFIX}")
+@@ -817,7 +815,7 @@ if(SDL2MIXER_INSTALL)
+         else()
+             set(PC_DESTDIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+         endif()
+-        # Only install a SDL2_mixer.pc file in Release mode
++        # Always install SDL2_mixer.pc file: libraries might be different between config modes
+         install(CODE "
+             # FIXME: use file(COPY_FILE) if minimum CMake version >= 3.21
+             execute_process(COMMAND \"\${CMAKE_COMMAND}\" -E copy_if_different
+@@ -825,8 +823,7 @@ if(SDL2MIXER_INSTALL)
+                 \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_mixer.pc\")
+             file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${PC_DESTDIR}\"
+                 TYPE FILE
+-                FILES \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_mixer.pc\")" CONFIG Release COMPONENT devel)
+-    endif()
++                FILES \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_mixer.pc\")" COMPONENT devel)
+ 
+     if(SDL2MIXER_BUILD_SHARED_LIBS AND (APPLE OR (UNIX AND NOT ANDROID)))
+         install(
+diff --git a/SDL2_mixer.pc.in b/SDL2_mixer.pc.in
+index c14ffb65..a7ec8660 100644
+--- a/SDL2_mixer.pc.in
++++ b/SDL2_mixer.pc.in
+@@ -1,4 +1,4 @@
+-prefix=@prefix@
++prefix=${PSPDEV}/psp
+ exec_prefix=@exec_prefix@
+ libdir=@libdir@
+ includedir=@includedir@

--- a/sdl2-ttf/PSPBUILD
+++ b/sdl2-ttf/PSPBUILD
@@ -1,5 +1,5 @@
 pkgname=sdl2-ttf
-pkgver=2.21.0
+pkgver=2.20.2
 pkgrel=1
 pkgdesc="a companion library to SDL2 for working with TrueType (tm) fonts"
 arch=('mips')
@@ -9,44 +9,46 @@ depends=('sdl2' 'freetype2')
 makedepends=()
 optdepends=()
 source=(
-    "git+https://github.com/libsdl-org/SDL_ttf.git#commit=fb8767cc692dcba6a3dbc020e71b74bf7bb993c5"
-    "main.c.sample"
+    "https://github.com/libsdl-org/SDL_ttf/releases/download/release-${pkgver}/SDL2_ttf-${pkgver}.tar.gz"
+    "pkg-config-fix.patch"
     "CMakeLists.txt.sample"
-    "Pacifico.ttf.sample"
+    "main.c.sample"
     "Pacifico.OFL.txt"
+    "Pacifico.ttf.sample"
 )
 sha256sums=(
-    'SKIP'
-    'SKIP'
-    'SKIP'
-    'SKIP'
-    'SKIP'
+    "9dc71ed93487521b107a2c4a9ca6bf43fb62f6bddd5c26b055e6b91418a22053"
+    "68917e29593eaf1fadd01e820834530be6cec63ae56def3e5f156e68aa44c713"
+    "66d0f0e1f76228e8888145bf6f21d107fff3d4dc9e0a83be2d27ea579c95c30d"
+    "e8b8fe841120a098e4baab28903403eb2a3fd0eeb184b46578efcb20699e0a6e"
+    "857c9cfe99da9b1cb313234885d0909f4d36545410bb6e6d6b944340d1331d91"
+    "4dac9db3fa9ca072f7861fd916bf04bdceac6069d0f3a886f5e523d922e918f1"
 )
 
 prepare() {
-    cd "$srcdir/SDL_ttf"
-    sed -i 's#@prefix@#${PSPDEV}/psp#' SDL2_ttf.pc.in
+    cd "${srcdir}/SDL2_ttf-${pkgver}"
+    patch -Np1 -i "${srcdir}/pkg-config-fix.patch"
 }
 
 build() {
-  cd "$srcdir/SDL_ttf"
-  mkdir -p build
-  cd build
-  cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=/psp \
-    -DBUILD_SHARED_LIBS=OFF -DSDL2TTF_SAMPLES=OFF -DSDL2TTF_VENDORED=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=OFF \
-    -DSDL2TTF_INSTALL=ON "${XTRA_OPTS[@]}" .. || { exit 1; }
-  make --quiet $MAKEFLAGS || { exit 1; }
+    cd "${srcdir}/SDL2_ttf-${pkgver}"
+    mkdir -p build
+    cd build
+    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE="${PSPDEV}/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX=/psp \
+        -DBUILD_SHARED_LIBS=OFF -DSDL2TTF_SAMPLES=OFF -DSDL2TTF_VENDORED=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=OFF \
+        -DSDL2TTF_INSTALL=ON "${XTRA_OPTS[@]}" .. || { exit 1; }
+    make --quiet $MAKEFLAGS || { exit 1; }
 }
 
 package() {
-  mkdir -p "$pkgdir/psp/sdk/samples/sdl2/ttf/"
-  install -m 644 $srcdir/main.c.sample $pkgdir/psp/sdk/samples/sdl2/ttf/main.c
-  install -m 644 $srcdir/CMakeLists.txt.sample $pkgdir/psp/sdk/samples/sdl2/ttf/CMakeLists.txt
-  install -m 644 $srcdir/Pacifico.ttf.sample $pkgdir/psp/sdk/samples/sdl2/ttf/Pacifico.ttf
-  install -m 644 $srcdir/Pacifico.OFL.txt $pkgdir/psp/sdk/samples/sdl2/ttf/OFL.txt
+    mkdir -p "${pkgdir}/psp/sdk/samples/sdl2/ttf/"
+    install -m 644 "${srcdir}/main.c.sample" "${pkgdir}/psp/sdk/samples/sdl2/ttf/main.c"
+    install -m 644 "${srcdir}/CMakeLists.txt.sample" "${pkgdir}/psp/sdk/samples/sdl2/ttf/CMakeLists.txt"
+    install -m 644 "${srcdir}/Pacifico.ttf.sample" "${pkgdir}/psp/sdk/samples/sdl2/ttf/Pacifico.ttf"
+    install -m 644 "${srcdir}/Pacifico.OFL.txt" "${pkgdir}/psp/sdk/samples/sdl2/ttf/OFL.txt"
 
-  cd "$srcdir/SDL_ttf/build"
-  make --quiet DESTDIR=$pkgdir $MAKEFLAGS install
+    cd "${srcdir}/SDL2_ttf-${pkgver}/build"
+    make --quiet DESTDIR="${pkgdir}" ${MAKEFLAGS} install
 
-  mv "$pkgdir/psp/share/licenses/SDL2_ttf" "$pkgdir/psp/share/licenses/$pkgname"
+    mv "${pkgdir}/psp/share/licenses/SDL2_ttf" "${pkgdir}/psp/share/licenses/${pkgname}"
 }

--- a/sdl2-ttf/pkg-config-fix.patch
+++ b/sdl2-ttf/pkg-config-fix.patch
@@ -1,0 +1,43 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 4ea903d..1ea756f 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -325,8 +325,6 @@ if(SDL2TTF_INSTALL)
+         COMPONENT devel
+     )
+ 
+-    if(SDL2TTF_BUILD_SHARED_LIBS)
+-        # Only create a .pc file for a shared SDL2_ttf
+         set(prefix "${CMAKE_INSTALL_PREFIX}")
+         set(exec_prefix "\${prefix}")
+         set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+@@ -346,15 +344,15 @@ if(SDL2TTF_INSTALL)
+         else()
+             set(PC_DESTDIR "${CMAKE_INSTALL_LIBDIR}/pkgconfig")
+         endif()
+-        # Only install a SDL2_ttf.pc file in Release mode
++        # Always install SDL2_ttf.pc file: libraries might be different between config modes
+         install(CODE "
+         # FIXME: use file(COPY_FILE) if CMake 3.21+
+-        execute_process(COMMAND \"${CMAKE_COMMAND}\" -E copy \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_ttf-$<CONFIG>.pc\"
++            execute_process(COMMAND \"${CMAKE_COMMAND}\" -E copy_if_different
++            \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_ttf-$<CONFIG>.pc\"
+             \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_ttf.pc\")
+         file(INSTALL DESTINATION \"\${CMAKE_INSTALL_PREFIX}/${PC_DESTDIR}\"
+             TYPE FILE
+-            FILES \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_ttf.pc\")" CONFIG Release)
+-    endif()
++            FILES \"${CMAKE_CURRENT_BINARY_DIR}/SDL2_ttf.pc\")" COMPONENT devel)
+ 
+     if(SDL2TTF_BUILD_SHARED_LIBS AND (APPLE OR (UNIX AND NOT ANDROID)))
+         install(FILES
+diff --git a/SDL2_ttf.pc.in b/SDL2_ttf.pc.in
+index 71d3d1b..66235a8 100644
+--- a/SDL2_ttf.pc.in
++++ b/SDL2_ttf.pc.in
+@@ -1,4 +1,4 @@
+-prefix=@prefix@
++prefix=${PSPDEV}/psp
+ exec_prefix=@exec_prefix@
+ libdir=@libdir@
+ includedir=@includedir@

--- a/sdl2/PSPBUILD
+++ b/sdl2/PSPBUILD
@@ -11,21 +11,20 @@ optdepends=()
 provides=('sdl2-main')
 source=(
     "https://github.com/libsdl-org/SDL/releases/download/release-${pkgver}/SDL2-${pkgver}.tar.gz"
+    "pkg-config-fix.patch"
     "CMakeLists.txt.sample"
     "main.c.sample"
 )
 sha256sums=(
     "d215ae4541e69d628953711496cd7b0e8b8d5c8d811d5b0f98fdc7fd1422998a"
+    "4f3bf0dd850d778c4e496f5c4d1a9827d28aa094335ef5d8cca4ce36b62e3012"
     "47b2ce55d1e0a15a8d355c957576cc11eaf089638c5560ecb142d08fe90c74c6"
     "a14f3f8bd70f5be01d7e4230450558431230082deef064df30aaeeb34a73a33c"
 )
 
 prepare() {
     cd "${srcdir}/SDL2-${pkgver}"
-    sed -i 's#@prefix@#${PSPDEV}/psp#' sdl2-config.in sdl2.pc.in
-    sed -i 's#@exec_prefix@#${prefix}#' sdl2-config.in sdl2.pc.in
-    sed -i 's#@libdir@#${prefix}/lib#' sdl2-config.in sdl2.pc.in
-    sed -i 's#@includedir@#${prefix}/include#' sdl2-config.in sdl2.pc.in
+    patch -Np1 -i "${srcdir}/pkg-config-fix.patch"
 }
 
 build() {

--- a/sdl2/PSPBUILD
+++ b/sdl2/PSPBUILD
@@ -1,5 +1,5 @@
 pkgname=sdl2
-pkgver=2.28.0
+pkgver=2.28.1
 pkgrel=1
 pkgdesc="a library designed to provide low level access to audio, input, and graphics hardware"
 arch=('mips')
@@ -16,7 +16,7 @@ source=(
     "main.c.sample"
 )
 sha256sums=(
-    "d215ae4541e69d628953711496cd7b0e8b8d5c8d811d5b0f98fdc7fd1422998a"
+    "4977ceba5c0054dbe6c2f114641aced43ce3bf2b41ea64b6a372d6ba129cb15d"
     "4f3bf0dd850d778c4e496f5c4d1a9827d28aa094335ef5d8cca4ce36b62e3012"
     "47b2ce55d1e0a15a8d355c957576cc11eaf089638c5560ecb142d08fe90c74c6"
     "a14f3f8bd70f5be01d7e4230450558431230082deef064df30aaeeb34a73a33c"

--- a/sdl2/PSPBUILD
+++ b/sdl2/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=sdl2
-pkgver=2.25.0
-pkgrel=4
+pkgver=2.28.0
+pkgrel=1
 pkgdesc="a library designed to provide low level access to audio, input, and graphics hardware"
 arch=('mips')
 url="https://github.com/libsdl-org/SDL"
@@ -10,18 +10,18 @@ makedepends=()
 optdepends=()
 provides=('sdl2-main')
 source=(
-    "git+https://github.com/libsdl-org/SDL.git#commit=428b5ae5464d567881c383edeb2d1e5712b18ffd"
-    "main.c.sample"
+    "https://github.com/libsdl-org/SDL/releases/download/release-${pkgver}/SDL2-${pkgver}.tar.gz"
     "CMakeLists.txt.sample"
+    "main.c.sample"
 )
 sha256sums=(
-    'SKIP'
-    'SKIP'
-    'SKIP'
+    "d215ae4541e69d628953711496cd7b0e8b8d5c8d811d5b0f98fdc7fd1422998a"
+    "47b2ce55d1e0a15a8d355c957576cc11eaf089638c5560ecb142d08fe90c74c6"
+    "a14f3f8bd70f5be01d7e4230450558431230082deef064df30aaeeb34a73a33c"
 )
 
 prepare() {
-    cd SDL
+    cd "${srcdir}/SDL2-${pkgver}"
     sed -i 's#@prefix@#${PSPDEV}/psp#' sdl2-config.in sdl2.pc.in
     sed -i 's#@exec_prefix@#${prefix}#' sdl2-config.in sdl2.pc.in
     sed -i 's#@libdir@#${prefix}/lib#' sdl2-config.in sdl2.pc.in
@@ -29,21 +29,20 @@ prepare() {
 }
 
 build() {
-    cd SDL
-    mkdir -p build
-    cd build
-    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=/psp -DBUILD_SHARED_LIBS=OFF \
-    -DSDL_TESTS=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
+    cd "${srcdir}/SDL2-${pkgver}"
+    mkdir -p build && cd build
+    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE="${PSPDEV}/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX=/psp \
+        -DBUILD_SHARED_LIBS=OFF -DSDL_TESTS=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 
 package() {
-    mkdir -p "$pkgdir/psp/sdk/samples/sdl2/basic/"
-    install -m 644 $srcdir/main.c.sample $pkgdir/psp/sdk/samples/sdl2/basic/main.c
-    install -m 644 $srcdir/CMakeLists.txt.sample $pkgdir/psp/sdk/samples/sdl2/basic/CMakeLists.txt
+    mkdir -p "${pkgdir}/psp/sdk/samples/sdl2/basic/"
+    install -m 644 "${srcdir}/main.c.sample" "${pkgdir}/psp/sdk/samples/sdl2/basic/main.c"
+    install -m 644 "${srcdir}/CMakeLists.txt.sample" "${pkgdir}/psp/sdk/samples/sdl2/basic/CMakeLists.txt"
 
-    cd SDL/build
-    make --quiet DESTDIR=$pkgdir $MAKEFLAGS install
+    cd "${srcdir}/SDL2-${pkgver}/build"
+    make --quiet DESTDIR="${pkgdir}" $MAKEFLAGS install
 
-    mv "$pkgdir/psp/share/licenses/SDL2" "$pkgdir/psp/share/licenses/$pkgname"
+    mv "${pkgdir}/psp/share/licenses/SDL2" "${pkgdir}/psp/share/licenses/${pkgname}"
 }

--- a/sdl2/PSPBUILD
+++ b/sdl2/PSPBUILD
@@ -31,7 +31,7 @@ build() {
     cd "${srcdir}/SDL2-${pkgver}"
     mkdir -p build && cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE="${PSPDEV}/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX=/psp \
-        -DBUILD_SHARED_LIBS=OFF -DSDL_TESTS=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DBUILD_SHARED_LIBS=OFF -DSDL_TESTS=OFF -DSDL_TEST=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/sdl2/pkg-config-fix.patch
+++ b/sdl2/pkg-config-fix.patch
@@ -1,0 +1,12 @@
+diff --git a/sdl2.pc.in b/sdl2.pc.in
+index 23a1d69c6..1c22f53f5 100644
+--- a/sdl2.pc.in
++++ b/sdl2.pc.in
+@@ -1,6 +1,6 @@
+ # sdl pkg-config source file
+ 
+-prefix=@prefix@
++prefix=${PSPDEV}/psp
+ exec_prefix=@exec_prefix@
+ libdir=@libdir@
+ includedir=@includedir@


### PR DESCRIPTION
This also cleans up the PSPBUILD files a lot. I made patches instead of offering versions that do not exist. These will probably be the final packages for sdl2.