### PR TITLE
Fix sdl2 license issue

### DIFF
--- a/libxmp-lite/PSPBUILD
+++ b/libxmp-lite/PSPBUILD
@@ -1,0 +1,35 @@
+pkgname=libxmp-lite
+pkgver=4.6.0
+pkgrel=1
+pkgdesc="Libxmp is a library that renders module files to PCM data"
+arch=('mips')
+url="https://github.com/libxmp/libxmp"
+license=('MIT')
+depends=()
+makedepends=()
+optdepends=()
+source=("https://github.com/libxmp/libxmp/releases/download/libxmp-${pkgver}/${pkgname}-${pkgver}.tar.gz")
+sha256sums=('71a93eb0119824bcc56eca95db154d1cdf30304b33d89a4732de6fef8a2c6f38')
+
+prepare() {
+    cd "${srcdir}/${pkgname}-${pkgver}"
+    sed -i 's#@prefix@#${PSPDEV}/psp#' libxmp-lite.pc.in
+    sed -i 's#@libdir@#${prefix}/lib#' libxmp-lite.pc.in
+    sed -i 's#@includedir@#${prefix}/include#' libxmp-lite.pc.in
+}
+
+build() {
+    cd "${srcdir}/${pkgname}-${pkgver}"
+    mkdir -p build && cd build
+    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE="${PSPDEV}/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX=/psp -DBUILD_SHARED=OFF \
+        "${XTRA_OPTS[@]}" .. || { exit 1; }
+    make --quiet $MAKEFLAGS || { exit 1; }
+}
+
+package() {
+    cd "${srcdir}/${pkgname}-${pkgver}/build"
+    make --quiet $MAKEFLAGS DESTDIR="${pkgdir}/" install || { exit 1; }
+
+    mkdir -m 755 -p "${pkgdir}/psp/share/licenses/${pkgname}"
+    install -m 644 ../README "${pkgdir}/psp/share/licenses/${pkgname}"
+}

--- a/sdl2-mixer/PSPBUILD
+++ b/sdl2-mixer/PSPBUILD
@@ -1,16 +1,17 @@
 pkgname=sdl2-mixer
 pkgver=2.6.3
-pkgrel=3
+pkgrel=4
 pkgdesc="an audio mixer library based on the SDL2 library"
 arch=('mips')
 url="https://www.libsdl.org/projects/SDL_mixer/"
 license=('MIT')
-depends=('sdl2' 'libxmp' 'libvorbis' 'libogg')
+depends=('sdl2' 'libxmp-lite' 'libvorbis' 'libogg')
 makedepends=()
 optdepends=()
 source=(
     "https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-${pkgver}.tar.gz"
     "pkg-config-fix.patch"
+    "libxmp-lite-fix.patch"
     "CMakeLists.txt.sample"
     "main.c.sample"
     "test.ogg.sample"
@@ -18,6 +19,7 @@ source=(
 sha256sums=(
     "7a6ba86a478648ce617e3a5e9277181bc67f7ce9876605eea6affd4a0d6eea8f"
     "5cd916deff335df405df54fbcac9ad833e9ea69af38de104d87982e5161c07ca"
+    "3dc9b332adb6b08af12c7e5e4aa3b0165c9ef4ed3e6d7e8b2f1a57a83118ad2d"
     "de65e71e7fd1ef742f78f44fac404642f1c48f4bec227df6dee12b0b5b7f2cd0"
     "02398828cf31287f3eff72baf605d05df6abf4b1b26d823fe30dff1469499c26"
     "6e506fae57ce4700e6f0a05adc31a95e66840080f889e7df247c08df180fdcd8"
@@ -26,6 +28,7 @@ sha256sums=(
 prepare() {
     cd "${srcdir}/SDL2_mixer-${pkgver}"
     patch -Np1 -i "${srcdir}/pkg-config-fix.patch"
+    patch -Np1 -i "${srcdir}/libxmp-lite-fix.patch"
 }
 
 build() {
@@ -35,7 +38,8 @@ build() {
         -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=OFF -DSDL2MIXER_DEPS_SHARED=OFF \
         -DSDL2MIXER_INSTALL=ON -DSDL2MIXER_SAMPLES=OFF -DSDL2MIXER_FLAC=OFF -DSDL2MIXER_OPUS=OFF \
         -DSDL2MIXER_MIDI=OFF -DSDL2MIXER_VORBIS=VORBISFILE -DSDL2MIXER_VORBIS_VORBISFILE_SHARED=OFF \
-        -DSDL2MIXER_MOD=ON -DSDL2MIXER_MOD_MODPLUG=OFF -DSDL2MIXER_MOD_XMP=ON .. "${XTRA_OPTS[@]}" || { exit 1; }
+        -DSDL2MIXER_MOD=ON -DSDL2MIXER_MOD_MODPLUG=OFF -DSDL2MIXER_MOD_XMP=ON -DSDL2MIXER_MOD_XMP_LITE=ON \
+        -DSDL2MIXER_MOD_XMP_SHARED=OFF .. "${XTRA_OPTS[@]}" || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/sdl2-mixer/libxmp-lite-fix.patch
+++ b/sdl2-mixer/libxmp-lite-fix.patch
@@ -1,0 +1,56 @@
+diff --git a/CMakeLists.txt b/CMakeLists.txt
+index 54317572..2d5baaaa 100644
+--- a/CMakeLists.txt
++++ b/CMakeLists.txt
+@@ -589,10 +589,10 @@ if(SDL2MIXER_MOD_XMP)
+     if(SDL2MIXER_MOD_XMP_LITE)
+         message(STATUS "Using system libxmp-lite")
+         find_package(libxmp-lite REQUIRED)
+-        set(tgt_xmp libxmp-lite::libxmp-lite)
++        set(tgt_xmp libxmp-lite)
+         set(xmp_name libxmp-lite)
+         if(NOT SDL2MIXER_MOD_XMP_SHARED)
+-            list(APPEND PC_REQUIRES libxmplite)
++            list(APPEND PC_REQUIRES libxmp-lite)
+         endif()
+     else()
+         message(STATUS "Using system libxmp")
+diff --git a/cmake/Findlibxmp-lite.cmake b/cmake/Findlibxmp-lite.cmake
+index d0b2bbbb..911ed77b 100644
+--- a/cmake/Findlibxmp-lite.cmake
++++ b/cmake/Findlibxmp-lite.cmake
+@@ -1,9 +1,10 @@
+ find_library(libxmp_lite_LIBRARY
+-    NAMES xmp
++    NAMES xmp-lite
+ )
+ 
+ find_path(libxmp_lite_INCLUDE_PATH
+     NAMES xmp.h
++    PATH_SUFFIXES libxmp-lite
+ )
+ 
+ set(libxmp_lite_COMPILE_OPTIONS "" CACHE STRING "Extra compile options of libxmp_lite")
+@@ -12,20 +13,19 @@ set(libxmp_lite_LINK_LIBRARIES "" CACHE STRING "Extra link libraries of libxmp_l
+ 
+ set(libxmp_lite_LINK_FLAGS "" CACHE STRING "Extra link flags of libxmp_lite")
+ 
+-find_package_handle_standard_args(libxmp_lite
++find_package_handle_standard_args(libxmp-lite
+     REQUIRED_VARS libxmp_lite_LIBRARY libxmp_lite_INCLUDE_PATH
+ )
+ 
+ if(libxmp_lite_FOUND)
+     if(NOT TARGET libxmp-lite::libxmp-lite)
+         add_library(libxmp-lite::libxmp-lite UNKNOWN IMPORTED)
+-        set_target_properties(libxmp_lite::libxmp_lite-shared PROPERTIES
++        set_target_properties(libxmp_lite::libxmp_lite PROPERTIES
+             IMPORTED_LOCATION "${libxmp_lite_LIBRARY}"
+             INTERFACE_INCLUDE_DIRECTORIES "${libxmp_lite_INCLUDE_PATH}"
+             INTERFACE_COMPILE_OPTIONS "${libxmp_lite_COMPILE_OPTIONS}"
+             INTERFACE_LINK_LIBRARIES "${libxmp_lite_LINK_LIBRARIES}"
+             INTERFACE_LINK_FLAGS "${libxmp_lite_LINK_FLAGS}"
+         )
+-        endif()
+     endif()
+ endif()


### PR DESCRIPTION
Since libmikmod support was removed from SDL2_mixer, I was linking to libxmp instead. Issue is, libxmp uses the GPL license, which is a big problem for software using it. This changes this to use libxmp-lite, which uses the MIT license, resolving the issue.