### PR TITLE
Fix un7zip library file name

### DIFF
--- a/libun7zip/PSPBUILD
+++ b/libun7zip/PSPBUILD
@@ -17,7 +17,7 @@ build() {
 package () {
   cd "$pkgname"
   mkdir -m 755 -p "$pkgdir/psp/lib" "$pkgdir/psp/include"
-  install -m 644 psp-libun7zip.a "$pkgdir/psp/lib/"
+  install -m 644 psp-libun7zip.a "$pkgdir/psp/lib/libun7zip.a"
   install -m 644 include/7zExtractor.h "$pkgdir/psp/include/un7zip.h"
 
   mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"

--- a/libun7zip/PSPBUILD
+++ b/libun7zip/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=libun7zip
 pkgver=19.00
-pkgrel=1
+pkgrel=2
 pkgdesc="A library that provides 7-Zip (.7z) archive handling and extraction"
 arch=('mips')
 license=('Apache-2.0 license')


### PR DESCRIPTION
Compiled library should be `libun7zip.a` but it was installed as `psp-libun7zip.a`

This PR fixes the installation file name of the un7zip compiled library.

