### PR TITLE
Fix OpenAL build

### DIFF
--- a/openal/PSPBUILD
+++ b/openal/PSPBUILD
@@ -1,13 +1,13 @@
 pkgname=openal
 pkgver=1.21.1
-pkgrel=2
+pkgrel=3
 pkgdesc="a cross-platform 3D audio API"
 arch=('mips')
 license=('gpl2')
 url="https://openal-soft.org/"
 makedepends=()
-source=("https://openal-soft.org/openal-releases/openal-soft-${pkgver}.tar.bz2")
-sha256sums=('c8ad767e9a3230df66756a21cc8ebf218a9d47288f2514014832204e666af5d8')
+source=("https://github.com/kcat/openal-soft/archive/refs/tags/${pkgver}.tar.gz")
+sha256sums=('8ac17e4e3b32c1af3d5508acfffb838640669b4274606b7892aa796ca9d7467f')
 
 prepare() {
     cd $pkgname-soft-$pkgver


### PR DESCRIPTION
It seems the tar.gz we use is not around anymore.