### PR TITLE
Resolve deprecation warnings in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     container: node:lts
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install dependencies
         id: set-matrix
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
         package: ${{ fromJson(needs.prepare_jobs.outputs.non_dependant) }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build package
       run: |
         adduser -D -h /build -s /bin/bash build
@@ -43,7 +43,7 @@ jobs:
     - name: Store package
       run: |
         echo ${{ matrix.package }}
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: package
         path: ${{ matrix.package }}/*.pkg.tar.gz
@@ -58,8 +58,8 @@ jobs:
         package: ${{ fromJson(needs.prepare_jobs.outputs.dependant) }}
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/download-artifact@v3
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
     - name: Install package
       run: |
         adduser -D -h /build -s /bin/bash build
@@ -80,7 +80,7 @@ jobs:
       run: |
         export PACKAGE=`echo ${{ matrix.package }} | awk '{print $NF}'`
         echo "PACKAGE=$PACKAGE" >> $GITHUB_ENV
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: package
         path: ${{ env.PACKAGE }}/*.pkg.tar.gz
@@ -92,8 +92,8 @@ jobs:
     container: ghcr.io/pspdev/pspsdk:latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/download-artifact@v3
+    - uses: actions/checkout@v4
+    - uses: actions/download-artifact@v4
     - name: Install dependencies
       run: |
         apk --update add build-base bash gpgme-dev libarchive-tools libarchive-dev libtool doxygen libcrypto3
@@ -120,7 +120,7 @@ jobs:
     runs-on: ubuntu-latest
   
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
 
     - name: Extract DOCKER_TAG using tag name
       if: startsWith(github.ref, 'refs/tags/')
@@ -132,19 +132,19 @@ jobs:
       run: |
         echo "DOCKER_TAG=latest" >> $GITHUB_ENV
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v2
+      uses: docker/setup-qemu-action@v3
       
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v2
+      uses: docker/setup-buildx-action@v3
       
     - name: Login to Github registry
-      uses: docker/login-action@v2
+      uses: docker/login-action@v3
       with:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
         registry: ghcr.io
     
-    - uses: docker/build-push-action@v4
+    - uses: docker/build-push-action@v5
       with:
         push: true
         tags: ghcr.io/${{ github.repository }}:${{ env.DOCKER_TAG }}
@@ -157,7 +157,7 @@ jobs:
         export DISPATCH_ACTION="$(echo run_build)"
         echo "NEW_DISPATCH_ACTION=$DISPATCH_ACTION" >> $GITHUB_ENV
     - name: Repository Dispatch to pspdev
-      uses: peter-evans/repository-dispatch@v2
+      uses: peter-evans/repository-dispatch@v3
       with:
         repository: ${{ github.repository_owner }}/pspdev
         token: ${{ secrets.DISPATCH_TOKEN }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         echo ${{ matrix.package }}
     - uses: actions/upload-artifact@v4
       with:
-        name: package
+        name: artifact-${{ matrix.package }}
         path: ${{ matrix.package }}/*.pkg.tar.gz
 
   build_depends:
@@ -63,10 +63,9 @@ jobs:
     - name: Install package
       run: |
         adduser -D -h /build -s /bin/bash build
-        chown -R build:build /build ${PSPDEV} package
-        cd package
-        sudo -u build PATH=${PATH} PSPDEV=${PSPDEV} ${PSPDEV}/bin/psp-pacman -Udd --noconfirm *.pkg.tar.gz --overwrite '*'
-        cd ..
+        chown -R build:build /build  ${PSPDEV} artifact-*
+        sudo -u build PATH=${PATH} PSPDEV=${PSPDEV} ${PSPDEV}/bin/psp-pacman -Udd --noconfirm artifact-*/*.pkg.tar.gz --overwrite '*'
+
     - name: Build packages
       run: |
         for f in ${{ matrix.package }}; do
@@ -100,6 +99,8 @@ jobs:
     - name: Create repo files
       if: contains(github.ref,'refs/heads/master')
       run: |
+        mkdir package
+        cp artifact-*/*.pkg.tar.gz package/
         cd package
         ${PSPDEV}/share/pacman/bin/repo-add pspdev.db.tar.gz *.pkg.tar.gz
     - name: Upload files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,7 +81,7 @@ jobs:
         echo "PACKAGE=$PACKAGE" >> $GITHUB_ENV
     - uses: actions/upload-artifact@v4
       with:
-        name: package
+        name: artifact-${{ env.PACKAGE }}
         path: ${{ env.PACKAGE }}/*.pkg.tar.gz
 
   create_release:


### PR DESCRIPTION
Right now we get a lot of warnings that we should update our actions because they use an old node version. This should fix that.