### PR TITLE
Fix error in install-latest.sh script

### DIFF
--- a/install-latest.sh
+++ b/install-latest.sh
@@ -18,7 +18,7 @@ curl -s https://api.github.com/repos/${PACKAGES_REPO}/releases/latest \
 
 
 # Windows doesn't have pacman, so let's install manually
-if [ $2 = "manually" ]; then
+if [ "$2" = "manually" ]; then
     for package in *.pkg.tar.gz; do
         tar -xzf $package -C $PSPDEV
     done


### PR DESCRIPTION
This can be tested like this:
```
docker build --build-arg "BASE_DOCKER_IMAGE=ghcr.io/pspdev/pspsdk:latest" --build-arg "PACKAGES_REPO=pspdev/psp-packages" -t test .
```