### PR TITLE
Update SDL2 to version 2.30.2

### DIFF
--- a/sdl2/PSPBUILD
+++ b/sdl2/PSPBUILD
@@ -1,5 +1,5 @@
 pkgname=sdl2
-pkgver=2.28.1
+pkgver=2.30.2
 pkgrel=1
 pkgdesc="a library designed to provide low level access to audio, input, and graphics hardware"
 arch=('mips')
@@ -16,7 +16,7 @@ source=(
     "main.c.sample"
 )
 sha256sums=(
-    "4977ceba5c0054dbe6c2f114641aced43ce3bf2b41ea64b6a372d6ba129cb15d"
+    "891d66ac8cae51361d3229e3336ebec1c407a8a2a063b61df14f5fdf3ab5ac31"
     "4f3bf0dd850d778c4e496f5c4d1a9827d28aa094335ef5d8cca4ce36b62e3012"
     "47b2ce55d1e0a15a8d355c957576cc11eaf089638c5560ecb142d08fe90c74c6"
     "a14f3f8bd70f5be01d7e4230450558431230082deef064df30aaeeb34a73a33c"


### PR DESCRIPTION
This has a small fix for joystick detection in it. Otherwise this shouldn't really change anything for us.