### PR TITLE
Don't warn on incompatible pointer types

### DIFF
--- a/sdl/PSPBUILD
+++ b/sdl/PSPBUILD
@@ -24,6 +24,7 @@ build() {
     ./autogen.sh
     LDFLAGS="$LDFLAGS -L$(psp-config --pspsdk-path)/lib -L$(psp-config --psp-prefix)/lib -lc -lpspuser" \
     LIBS="$LIBS -lc -lpspuser" \
+    CFLAGS="-Wno-error=incompatible-pointer-types" \
     ./configure --host=psp --prefix=/psp --enable-pspirkeyb
     make
 }


### PR DESCRIPTION
Don't warn on incompatible pointers on SDL1.2 for now

We could potentially backport the changes from the SDL1.2 repo, I am not sure if the SDL team would be willing to add our PSP Repo back to 1.2 sources, I will check with them