### PR TITLE
Add tremor from psp-ports

### DIFF
--- a/tremor/PSPBUILD
+++ b/tremor/PSPBUILD
@@ -1,0 +1,42 @@
+pkgname=tremor
+pkgver=1.2.0git
+pkgrel=1
+pkgdesc="Integer-only, fully Ogg Vorbis compliant software decoder library"
+arch=('mips')
+url="https://wiki.xiph.org/Tremor"
+license=('BSD')
+depends=()
+makedepends=()
+optdepends=()
+source=(
+    "git+https://gitlab.xiph.org/xiph/tremor.git#commit=64350e068cb8488c1fec8e8c870dce936267e057"
+    "platform-allegrex.patch"
+)
+sha256sums=(
+    'SKIP'
+    'SKIP'
+)
+
+prepare() {
+    cd "${pkgname}"
+    patch -p1 < ../platform-allegrex.patch
+}
+
+build() {
+    cd "${pkgname}"
+    ./autogen.sh --host psp
+    LDFLAGS="-L$(psp-config --pspsdk-path)/lib" LIBS="-lc -lpspuser" \
+    ./configure --host psp --prefix=/psp
+    make
+}
+
+package() {
+    cd "${pkgname}"
+    make DESTDIR="$pkgdir/" install
+
+    rm "${pkgdir}/psp/lib/libvorbisidec.la"
+
+    mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
+    install -m 644 ../COPYING "$pkgdir/psp/share/licenses/$pkgname"
+}
+

--- a/tremor/PSPBUILD
+++ b/tremor/PSPBUILD
@@ -37,6 +37,6 @@ package() {
     rm "${pkgdir}/psp/lib/libvorbisidec.la"
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
-    install -m 644 ../COPYING "$pkgdir/psp/share/licenses/$pkgname"
+    install -m 644 COPYING "$pkgdir/psp/share/licenses/$pkgname"
 }
 

--- a/tremor/platform-allegrex.patch
+++ b/tremor/platform-allegrex.patch
@@ -1,0 +1,14 @@
+--- a/configure.in	2024-06-04 11:45:58.272647960 +0300
++++ b/configure.in	2024-06-04 11:41:15.900699359 +0300
+@@ -61,7 +61,10 @@
+                 DEBUG="-g -Wall -D__NO_MATH_INLINES -fsigned-char -D_ARM_ASSEM_"
+                 CFLAGS="-O2 -D_ARM_ASSEM_ -fsigned-char"
+                 PROFILE="-W -pg -g -O2 -D_ARM_ASSEM_ -fsigned-char -fno-inline-functions";;
+-
++        mipsallegrex*-*-*)
++                DEBUG="-g -W -fsigned-char"
++                CFLAGS="-O2 -G0 -fsigned-char -DLITTLE_ENDIAN=1 -DBYTE_ORDER=LITTLE_ENDIAN -D_LOW_ACCURACY_"
++                PROFILE="-W -pg -g -O2 -G0 -fsigned-char -fno-inline-functions";;
+         *)
+                 DEBUG="-g -Wall -D__NO_MATH_INLINES -fsigned-char"
+                 CFLAGS="-O2 -Wall -fsigned-char"


### PR DESCRIPTION
The only package that was not moved from psp-ports to psp-packages. Should be faster than vorbis and can be used as a drop-in replacement.

I tried to find the commit that the fork in psp-ports was based on, and extract the patch (turns out it's just adding 4 lines to configure script).