### PR TITLE
Update tremor to the latest source with modern patches

### DIFF
--- a/tremor/PSPBUILD
+++ b/tremor/PSPBUILD
@@ -1,31 +1,40 @@
 pkgname=tremor
-pkgver=1.2.0git
+pkgver=1.2.1git
 pkgrel=1
 pkgdesc="Integer-only, fully Ogg Vorbis compliant software decoder library"
 arch=('mips')
 url="https://wiki.xiph.org/Tremor"
 license=('BSD')
-depends=()
+depends=('libogg')
 makedepends=()
 optdepends=()
 source=(
-    "git+https://gitlab.xiph.org/xiph/tremor.git#commit=64350e068cb8488c1fec8e8c870dce936267e057"
+    "git+https://gitlab.xiph.org/xiph/tremor.git#commit=7c30a66346199f3f09017a09567c6c8a3a0eedc8"
+    "https://github.com/sezero/tremor/compare/master...sezero.patch"
     "platform-allegrex.patch"
 )
 sha256sums=(
     'SKIP'
+    '5bd4ac5916bda07e6f9dbdcd1633ac7073c7972b874b04ca59d5edde65afc847'
     'SKIP'
 )
 
 prepare() {
     cd "${pkgname}"
+    patch -p1 < ../master...sezero.patch
     patch -p1 < ../platform-allegrex.patch
+
+    sed -i 's#@prefix@#${PSPDEV}/psp#' vorbisidec.pc.in
+    sed -i 's#@exec_prefix@#${prefix}#' vorbisidec.pc.in
+    sed -i 's#@libdir@#${prefix}/lib#' vorbisidec.pc.in
+    sed -i 's#@includedir@#${prefix}/include#' vorbisidec.pc.in
 }
 
 build() {
     cd "${pkgname}"
     ./autogen.sh --host psp
     LDFLAGS="-L$(psp-config --pspsdk-path)/lib" LIBS="-lc -lpspuser" \
+    CFLAGS="-Wno-error=incompatible-pointer-types" \
     ./configure --host psp --prefix=/psp
     make
 }

--- a/tremor/platform-allegrex.patch
+++ b/tremor/platform-allegrex.patch
@@ -1,14 +1,16 @@
---- a/configure.in	2024-06-04 11:45:58.272647960 +0300
-+++ b/configure.in	2024-06-04 11:41:15.900699359 +0300
-@@ -61,7 +61,10 @@
-                 DEBUG="-g -Wall -D__NO_MATH_INLINES -fsigned-char -D_ARM_ASSEM_"
+diff --git a/configure.ac b/configure.ac
+index 6511f7f..bb2fba1 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -78,6 +78,11 @@ else
                  CFLAGS="-O2 -D_ARM_ASSEM_ -fsigned-char"
                  PROFILE="-W -pg -g -O2 -D_ARM_ASSEM_ -fsigned-char -fno-inline-functions";;
--
+ 
 +        mipsallegrex*-*-*)
 +                DEBUG="-g -W -fsigned-char"
 +                CFLAGS="-O2 -G0 -fsigned-char -DLITTLE_ENDIAN=1 -DBYTE_ORDER=LITTLE_ENDIAN -D_LOW_ACCURACY_"
 +                PROFILE="-W -pg -g -O2 -G0 -fsigned-char -fno-inline-functions";;
++
          *)
                  DEBUG="-g -Wall -D__NO_MATH_INLINES -fsigned-char"
                  CFLAGS="-O2 -Wall -fsigned-char"


### PR DESCRIPTION
There has been some development of this library since 2007 when it was ported to PSP. Most notably: using external libogg instead of the bundled one and support for pkgconfig. The master branch however doesn't play nice with modern autotools, but there is a fork [sezero/tremor](https://github.com/sezero/tremor/) with fixes.