### PR TITLE
Update harfbuzz and patch out stdc++ dependency

### DIFF
--- a/harfbuzz/PSPBUILD
+++ b/harfbuzz/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=harfbuzz
-pkgver=8.3.0
-pkgrel=2
+pkgver=8.5.0
+pkgrel=1
 pkgdesc="OpenType text shaping engine"
 arch=('mips')
 url="https://harfbuzz.github.io/"
@@ -13,8 +13,8 @@ source=(
   "fix-cmake.patch"
 )
 sha256sums=(
-  "109501eaeb8bde3eadb25fab4164e993fbace29c3d775bcaa1c1e58e2f15f847"
-  "110f08631404c3f4d9f99b58679a626384658369355c682f5cf152c375cb7386"
+  "77e4f7f98f3d86bf8788b53e6832fb96279956e1c3961988ea3d4b7ca41ddc27"
+  "SKIP"
 )
 
 prepare() {

--- a/harfbuzz/fix-cmake.patch
+++ b/harfbuzz/fix-cmake.patch
@@ -2,7 +2,7 @@ diff --git a/CMakeLists.txt b/CMakeLists.txt
 index e22f2cf..b739707 100644
 --- a/CMakeLists.txt
 +++ b/CMakeLists.txt
-@@ -116,11 +116,17 @@ if (NOT MSVC)
+@@ -117,7 +117,9 @@ if (NOT MSVC)
    find_package(Threads)
    if (CMAKE_USE_PTHREADS_INIT)
      add_definitions("-DHAVE_PTHREAD")
@@ -13,11 +13,12 @@ index e22f2cf..b739707 100644
      list(APPEND PC_LIBS_PRIV -pthread)
    endif ()
  endif ()
- 
-+if (PSP)
-+  list(APPEND PC_LIBS_PRIV -lstdc++)
-+endif ()
-+
- if (MSVC)
-   add_definitions(-wd4244 -wd4267 -D_CRT_SECURE_NO_WARNINGS -D_CRT_NONSTDC_NO_WARNINGS)
+@@ -502,7 +504,7 @@ if (HB_BUILD_SUBSET)
+   endif ()
  endif ()
+ 
+-if (UNIX OR MINGW OR VITA)
++if (UNIX OR MINGW OR VITA OR PSP)
+   # Make symbols link locally
+   include (CheckCXXCompilerFlag)
+   CHECK_CXX_COMPILER_FLAG(-Bsymbolic-functions CXX_SUPPORTS_FLAG_BSYMB_FUNCS)


### PR DESCRIPTION
Just today I looked at how VITA community cooks their harfbuzz, so I copied the approach described in https://github.com/vitasdk/packages/issues/300, and it works really well: got SDL2-ttf sample (in C) built linking to harfbuzz, but not stdc++. Previously, I only built Jokr (written in C++) with it, so linking to stdc++ didn't bother me that much.