### PR TITLE
Use GitHub pages for hosting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,7 +56,7 @@ jobs:
         name: artifact-${{ env.PACKAGE }}
         path: ${{ env.PACKAGE }}/*.pkg.tar.gz
 
-  create_repo:
+  package_repo:
     if: contains(github.ref,'refs/heads/master')
     needs: [prepare_jobs, build]
     runs-on: ubuntu-latest
@@ -81,9 +81,9 @@ jobs:
         name: github-pages
         path: repo.tar
 
-  upload_repo:
+  publish_repo:
     if: contains(github.ref,'refs/heads/master')
-    needs: [create_repo]
+    needs: [package_repo]
     runs-on: ubuntu-latest
     environment:
       name: github-pages
@@ -98,8 +98,7 @@ jobs:
 
   docker-layer:
     if: contains(github.ref,'refs/heads/master')
-    needs: [upload_repo]
-  
+    needs: [publish_repo]
     runs-on: ubuntu-latest
   
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -6,6 +6,11 @@ on:
   repository_dispatch:
     types: [run_build]
 
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
 jobs:
   prepare_jobs:
     runs-on: ubuntu-latest
@@ -51,7 +56,7 @@ jobs:
         name: artifact-${{ env.PACKAGE }}
         path: ${{ env.PACKAGE }}/*.pkg.tar.gz
 
-  create_release:
+  create_repo:
     if: contains(github.ref,'refs/heads/master')
     needs: [prepare_jobs, build]
     runs-on: ubuntu-latest
@@ -59,31 +64,41 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
-    - uses: actions/download-artifact@v4
-    - name: Install dependencies
-      run: |
-        apk --update add build-base bash gpgme-dev libarchive-tools libarchive-dev libtool doxygen libcrypto3
+    - name: Download artifacts
+      uses: actions/download-artifact@v4
     - name: Create repo files
-      if: contains(github.ref,'refs/heads/master')
       run: |
-        mkdir package
-        cp artifact-*/*.pkg.tar.gz package/
-        cd package
+        mkdir repo
+        cp artifact-*/*.pkg.tar.gz repo/
+        cd repo
         ${PSPDEV}/share/pacman/bin/repo-add pspdev.db.tar.gz *.pkg.tar.gz
-    - name: Upload files
-      if: contains(github.ref,'refs/heads/master')
-      uses: svenstaro/upload-release-action@v2
+        mv pspdev.db.tar.gz pspdev.db
+        mv pspdev.files.tar.gz pspdev.files
+        tar -cvf ../repo.tar ./*
+    - name: Upload repo artifact
+      uses: actions/upload-artifact@v4
       with:
-        repo_token: ${{ secrets.GITHUB_TOKEN }}
-        file: package/*
-        overwrite: true
-        file_glob: true
-        tag: ${{ github.ref }}-${{ github.run_id }}
-        release_name: ${{ github.ref }} (${{ github.run_id }})
+        name: github-pages
+        path: repo.tar
+
+  upload_repo:
+    if: contains(github.ref,'refs/heads/master')
+    needs: [create_repo]
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
 
   docker-layer:
     if: contains(github.ref,'refs/heads/master')
-    needs: [create_release]
+    needs: [upload_repo]
   
     runs-on: ubuntu-latest
   


### PR DESCRIPTION
The system with releases we use right now doesn't work so well. While we are releasing there is a chance that you might not get your package and we have over 300 releases on this repo of which only the last one is ever used.

This PR makes it so we upload to GitHub Pages instead, which then hosts our repo for us. It does not leave old stuff lying around, it just deploys the artifact we give it. We could also later expand it to have a web page in front like @tpimh suggested.

This does require a change in the psp-pacman repo and a rebuild from there after merging. Merging this won't cause errors directly, but the releases will stop being updated. It is possible that in the settings of this repo, GitHub Pages will need to be set to "GitHub Action" before the pipeline goes through.

If you want to make sure it works, I have the exact same workflow file building just fine here: https://github.com/sharkwouter/psp-packages/actions/runs/9390313802

If you change the `Server` field at the bottom of `$PSPDEV/etc/pacman.conf` to `https://sharkwouter.github.io/psp-packages/` you can test with it and see it in action.