### PR TITLE
update sources SDL2_(image, net, mixer)

### DIFF
--- a/sdl2-image/PSPBUILD
+++ b/sdl2-image/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=sdl2-image
 pkgver=2.6.3
-pkgrel=2
+pkgrel=3
 pkgdesc="a simple library to load images of various formats as SDL surfaces"
 arch=('mips')
 url="https://wiki.libsdl.org/SDL2_image/FrontPage"
@@ -9,7 +9,7 @@ depends=('sdl2' 'libpng' 'jpeg')
 makedepends=()
 optdepends=()
 source=(
-    "https://www.libsdl.org/projects/SDL_image/release/SDL2_image-${pkgver}.tar.gz"
+    "https://github.com/libsdl-org/SDL_image/releases/download/release-${pkgver}/SDL2_image-${pkgver}.tar.gz"
 	"pkg-config-fix.patch"
 )
 sha256sums=(

--- a/sdl2-mixer/PSPBUILD
+++ b/sdl2-mixer/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=sdl2-mixer
 pkgver=2.6.3
-pkgrel=6
+pkgrel=7
 pkgdesc="an audio mixer library based on the SDL2 library"
 arch=('mips')
 url="https://wiki.libsdl.org/SDL2_mixer/FrontPage"
@@ -9,7 +9,7 @@ depends=('sdl2' 'libmodplug' 'libvorbis' 'libogg')
 makedepends=()
 optdepends=()
 source=(
-    "https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-${pkgver}.tar.gz"
+    "https://github.com/libsdl-org/SDL_mixer/releases/download/release-${pkgver}/SDL2_mixer-${pkgver}.tar.gz"
     "pkg-config-fix.patch"
     "CMakeLists.txt.sample"
     "main.c.sample"

--- a/sdl2-net/PSPBUILD
+++ b/sdl2-net/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=sdl2-net
 pkgver=2.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="a wrapper over TCP/IP sockets"
 arch=('mips')
 url="https://wiki.libsdl.org/SDL2_net/FrontPage"
@@ -9,7 +9,7 @@ depends=('sdl2')
 makedepends=()
 optdepends=()
 source=(
-    "https://www.libsdl.org/projects/SDL_net/release/SDL2_net-${pkgver}.tar.gz"
+    "https://github.com/libsdl-org/SDL_net/releases/download/release-${pkgver}/SDL2_net-${pkgver}.tar.gz"
     "${pkgname}-${pkgver}-PSP.patch"
 )
 sha256sums=(


### PR DESCRIPTION
fix for the CI error:

```
curl: (60) SSL certificate problem: unable to get local issuer certificate
More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could not
establish a secure connection to it. To learn more about this situation and
how to fix it, please visit the web page mentioned above.
==> ERROR: Failure while downloading https://www.libsdl.org/projects/SDL_mixer/release/SDL2_mixer-2.6.3.tar.gz
    Aborting...
Error: Process completed with exit code 1.
```