### PR TITLE
Add repo index pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -79,6 +79,8 @@ jobs:
         cd ..
     - name: Create repo index pages
       run: |
+        chown -R $(id -nu):$(id -ng) .
+        apk add --no-cache bash
         ./make-repo-html.sh
     - name: Upload repo artifact
       uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,6 +76,10 @@ jobs:
         mv pspdev.db.tar.gz pspdev.db
         mv pspdev.files.tar.gz pspdev.files
         tar -cvf ../repo.tar ./*
+        cd ..
+    - name: Create repo index pages
+      run: |
+        ./make-repo-html.sh
     - name: Upload repo artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
         ${PSPDEV}/share/pacman/bin/repo-add pspdev.db.tar.gz *.pkg.tar.gz
         mv pspdev.db.tar.gz pspdev.db
         mv pspdev.files.tar.gz pspdev.files
-        tar -cvf ../repo.tar ./*        
+        tar -cvf ../repo.tar ./*
     - name: Upload repo artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,6 +65,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
     - name: Download artifacts
       uses: actions/download-artifact@v4
     - name: Create repo files

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,19 +69,16 @@ jobs:
       uses: actions/download-artifact@v4
     - name: Create repo files
       run: |
+        chown -R $(id -nu):$(id -ng) .
+        apk add --no-cache bash coreutils
         mkdir repo
         cp artifact-*/*.pkg.tar.gz repo/
+        ./make-repo-html.sh
         cd repo
         ${PSPDEV}/share/pacman/bin/repo-add pspdev.db.tar.gz *.pkg.tar.gz
         mv pspdev.db.tar.gz pspdev.db
         mv pspdev.files.tar.gz pspdev.files
-        tar -cvf ../repo.tar ./*
-        cd ..
-    - name: Create repo index pages
-      run: |
-        chown -R $(id -nu):$(id -ng) .
-        apk add --no-cache bash coreutils
-        ./make-repo-html.sh
+        tar -cvf ../repo.tar ./*        
     - name: Upload repo artifact
       uses: actions/upload-artifact@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
     - name: Create repo index pages
       run: |
         chown -R $(id -nu):$(id -ng) .
-        apk add --no-cache bash
+        apk add --no-cache bash coreutils
         ./make-repo-html.sh
     - name: Upload repo artifact
       uses: actions/upload-artifact@v4

--- a/index.html
+++ b/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>${GITHUB_REPOSITORY_OWNER}&#39;s package index</title>
+    </head>
+    <body>
+        <p><h1>${GITHUB_REPOSITORY_OWNER}&#39;s package index</h1></p>
+        <table>
+            <tr><th>Name</th><th>Version</th><th>Description</th><th>Last Updated</th></tr>
+            ${INDEX_TABLE_CONTENT}
+        </table>
+        <p>Source on <a href="https://github.com/${GITHUB_REPOSITORY}/">GitHub</a></p>
+    </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
     <head>
         <title>${GITHUB_REPOSITORY_OWNER}&#39;s package index</title>
+        <link rel="stylesheet" href="style.css">
     </head>
     <body>
         <p><h1>${GITHUB_REPOSITORY_OWNER}&#39;s package index</h1></p>

--- a/make-repo-html.sh
+++ b/make-repo-html.sh
@@ -1,16 +1,60 @@
 #!/bin/bash
 
-mkdir -p repo
-export GITHUB_REPOSITORY_OWNER="${GITHUB_REPOSITORY_OWNER:-pspdev}"
-export GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-pspdev/pspdev}"
+#Change directory to the directory of this script
+cd "$(dirname "$0")"
 
-declare -a INDEX_TABLE_CONTENT
+# Export all variables
+set -a
+
+# Set global variables
+GITHUB_REPOSITORY_OWNER="${GITHUB_REPOSITORY_OWNER:-pspdev}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-pspdev/pspdev}"
+INDEX_TABLE_CONTENT=""
+
+# Build the html pages
 for PSPBUILD in $(find . -name "PSPBUILD" | sort); do
 		source "${PSPBUILD}"
 		UPDATED=$(git log -1 --format=%cd --date=short -- "${PSPBUILD}")
-		URL="${pkgname}-${pkgver}-${pkgrel}-${arch}.pkg.tar.gz"
-		INDEX_TABLE_CONTENT+=("<tr><td><a href=\"${pkgname}.html\">${pkgname}</a></td><td>${pkgver}-${pkgrel}</td><td>${pkgdesc}</td><td>${UPDATED}</td></tr>")
+		DOWNLOAD_URL="${pkgname}-${pkgver}-${pkgrel}-${arch}.pkg.tar.gz"
+
+		# Convert lists to strings
+		ARCH="${arch[*]}"
+		LICENSE="${license[*]}"
+
+		# Get file size info
+		FILENAME="repo/${DOWNLOAD_URL}"
+		if [ -f "${FILENAME}" ]; then
+			GZSTATS="$(gzip -l $FILENAME | tail -n 1 | tr -s ' ')"
+			PKGSIZE=$(echo $GZSTATS | cut -d ' ' -f 1 | numfmt --to=iec --suffix=B --format="%.2f")
+  			INSTSIZE=$(echo $GZSTATS | cut -d ' ' -f 2 | numfmt --to=iec --suffix=B --format="%.2f")
+		fi
+
+		# List dependencies
+		if [ ! -n "${depends[*]}" ]; then
+			DEPS="No dependencies"
+		else
+			DEPS="<ul>"
+			for dep in "${depends[@]}"; do
+				DEPS="${DEPS}<li><a href=\"${dep}.html\">${dep}</a></li>"
+			done
+			DEPS="${DEPS}</ul>"
+		fi
+
+		# List content of files
+		if [ -f "${FILENAME}" ]; then
+			CONTENT="<ul>"
+			for item in =$(tar tzf $FILENAME | grep -v '\.BUILDINFO\|\.MTREE\|\.PKGINFO'); do
+				CONTENT="${CONTENT}<li>${item}</li>"
+			done
+			CONTENT="${CONTENT}</ul>"
+		else
+			CONTENT="Not known"
+		fi
+
+		envsubst < package.html > "repo/${pkgname}.html"
+
+		INDEX_TABLE_CONTENT="${INDEX_TABLE_CONTENT}<tr><td><a href=\"${pkgname}.html\">${pkgname}</a></td><td>${pkgver}-${pkgrel}</td><td>${pkgdesc}</td><td>${UPDATED}</td></tr>"
 done
 
-ensubst < index.html > repo/index.html
-
+envsubst < index.html > repo/index.html
+cp style.css repo/

--- a/make-repo-html.sh
+++ b/make-repo-html.sh
@@ -27,9 +27,9 @@ for PSPBUILD in $(find . -name "PSPBUILD" | sort); do
 		# Get file size info
 		FILENAME="repo/${DOWNLOAD_URL}"
 		if [ -f "${FILENAME}" ]; then
-			//GZSTATS="$(gzip -l $FILENAME | tail -n 1 | tr -s ' ')"
-			//PKGSIZE=$(echo $GZSTATS | cut -d ' ' -f 1 | numfmt --to=iec --suffix=B --format="%.2f")
-  			//INSTSIZE=$(echo $GZSTATS | cut -d ' ' -f 2 | numfmt --to=iec --suffix=B --format="%.2f")
+			# GZSTATS="$(gzip -l $FILENAME | tail -n 1 | tr -s ' ')"
+			# PKGSIZE=$(echo $GZSTATS | cut -d ' ' -f 1 | numfmt --to=iec --suffix=B --format="%.2f")
+  			# INSTSIZE=$(echo $GZSTATS | cut -d ' ' -f 2 | numfmt --to=iec --suffix=B --format="%.2f")
 		fi
 
 		# List dependencies

--- a/make-repo-html.sh
+++ b/make-repo-html.sh
@@ -45,7 +45,7 @@ for PSPBUILD in $(find . -name "PSPBUILD" | sort); do
 		# List content of files
 		if [ -f "${FILENAME}" ]; then
 			CONTENT="<ul>"
-			for item in =$(tar tzf $FILENAME | grep -v '\.BUILDINFO\|\.MTREE\|\.PKGINFO'); do
+			for item in $(tar tzf $FILENAME | grep -v '\.BUILDINFO\|\.MTREE\|\.PKGINFO'); do
 				CONTENT="${CONTENT}<li>${item}</li>"
 			done
 			CONTENT="${CONTENT}</ul>"

--- a/make-repo-html.sh
+++ b/make-repo-html.sh
@@ -27,7 +27,7 @@ for PSPBUILD in $(find . -name "PSPBUILD" | sort); do
 		# Get file size info
 		FILENAME="repo/${DOWNLOAD_URL}"
 		if [ -f "${FILENAME}" ]; then
-  			PKGSIZE=$(du "${FILENAME}" | cut -f 1 | numfmt --to=iec --suffix=B --format="%.2f")
+  			PKGSIZE="$(ls -l  "${FILENAME}"|cut -d' ' -f5|numfmt --to iec --suffix=B --format "%.1f")"
 			INSTSIZE="$(gunzip -c "${FILENAME}"|grep -a '^size = '|cut -d' ' -f3|numfmt --to iec --suffix=B --format "%.1f")"
 		fi
 

--- a/make-repo-html.sh
+++ b/make-repo-html.sh
@@ -45,7 +45,7 @@ for PSPBUILD in $(find . -name "PSPBUILD" | sort); do
 		# List content of files
 		if [ -f "${FILENAME}" ]; then
 			CONTENT="<ul>"
-			for item in $(tar tzf $FILENAME | grep -v '\.BUILDINFO\|\.MTREE\|\.PKGINFO'); do
+			for item in $(tar -tzf $FILENAME | grep -v '\.BUILDINFO\|\.MTREE\|\.PKGINFO\|/$'); do
 				CONTENT="${CONTENT}<li>${item}</li>"
 			done
 			CONTENT="${CONTENT}</ul>"

--- a/make-repo-html.sh
+++ b/make-repo-html.sh
@@ -27,8 +27,8 @@ for PSPBUILD in $(find . -name "PSPBUILD" | sort); do
 		# Get file size info
 		FILENAME="repo/${DOWNLOAD_URL}"
 		if [ -f "${FILENAME}" ]; then
-  			INSTSIZE=$(du "${FILENAME}" | cut -d ' ' -f 1 | numfmt --to=iec --suffix=B --format="%.2f")
-			PKGSIZE="$(gunzip -c "${FILENAME}"|grep -a '^size = '|cut -d' ' -f3|numfmt --to iec --suffix=B --format "%.1f")"
+  			PKGSIZE=$(du "${FILENAME}" | cut -f 1 | numfmt --to=iec --suffix=B --format="%.2f")
+			INSTSIZE="$(gunzip -c "${FILENAME}"|grep -a '^size = '|cut -d' ' -f3|numfmt --to iec --suffix=B --format "%.1f")"
 		fi
 
 		# List dependencies

--- a/make-repo-html.sh
+++ b/make-repo-html.sh
@@ -6,6 +6,9 @@ cd "$(dirname "$0")"
 # Export all variables
 set -a
 
+# Fail on error
+set -e
+
 # Set global variables
 GITHUB_REPOSITORY_OWNER="${GITHUB_REPOSITORY_OWNER:-pspdev}"
 GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-pspdev/pspdev}"
@@ -24,9 +27,9 @@ for PSPBUILD in $(find . -name "PSPBUILD" | sort); do
 		# Get file size info
 		FILENAME="repo/${DOWNLOAD_URL}"
 		if [ -f "${FILENAME}" ]; then
-			GZSTATS="$(gzip -l $FILENAME | tail -n 1 | tr -s ' ')"
-			PKGSIZE=$(echo $GZSTATS | cut -d ' ' -f 1 | numfmt --to=iec --suffix=B --format="%.2f")
-  			INSTSIZE=$(echo $GZSTATS | cut -d ' ' -f 2 | numfmt --to=iec --suffix=B --format="%.2f")
+			//GZSTATS="$(gzip -l $FILENAME | tail -n 1 | tr -s ' ')"
+			//PKGSIZE=$(echo $GZSTATS | cut -d ' ' -f 1 | numfmt --to=iec --suffix=B --format="%.2f")
+  			//INSTSIZE=$(echo $GZSTATS | cut -d ' ' -f 2 | numfmt --to=iec --suffix=B --format="%.2f")
 		fi
 
 		# List dependencies

--- a/make-repo-html.sh
+++ b/make-repo-html.sh
@@ -27,9 +27,8 @@ for PSPBUILD in $(find . -name "PSPBUILD" | sort); do
 		# Get file size info
 		FILENAME="repo/${DOWNLOAD_URL}"
 		if [ -f "${FILENAME}" ]; then
-			# GZSTATS="$(gzip -l $FILENAME | tail -n 1 | tr -s ' ')"
-			# PKGSIZE=$(echo $GZSTATS | cut -d ' ' -f 1 | numfmt --to=iec --suffix=B --format="%.2f")
-  			# INSTSIZE=$(echo $GZSTATS | cut -d ' ' -f 2 | numfmt --to=iec --suffix=B --format="%.2f")
+  			INSTSIZE=$(du "${FILENAME}" | cut -d ' ' -f 1 | numfmt --to=iec --suffix=B --format="%.2f")
+			PKGSIZE="$(gunzip -c "${FILENAME}"|grep -a '^size = '|cut -d' ' -f3|numfmt --to iec --suffix=B --format "%.1f")"
 		fi
 
 		# List dependencies

--- a/make-repo-html.sh
+++ b/make-repo-html.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+mkdir -p repo
+export GITHUB_REPOSITORY_OWNER="${GITHUB_REPOSITORY_OWNER:-pspdev}"
+export GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-pspdev/pspdev}"
+
+declare -a INDEX_TABLE_CONTENT
+for PSPBUILD in $(find . -name "PSPBUILD" | sort); do
+		source "${PSPBUILD}"
+		UPDATED=$(git log -1 --format=%cd --date=short -- "${PSPBUILD}")
+		URL="${pkgname}-${pkgver}-${pkgrel}-${arch}.pkg.tar.gz"
+		INDEX_TABLE_CONTENT+=("<tr><td><a href=\"${pkgname}.html\">${pkgname}</a></td><td>${pkgver}-${pkgrel}</td><td>${pkgdesc}</td><td>${UPDATED}</td></tr>")
+done
+
+ensubst < index.html > repo/index.html
+

--- a/package.html
+++ b/package.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <title>${pkgname} - ${GITHUB_REPOSITORY_OWNER}&#39;s package index</title>
+        <link rel="stylesheet" href="style.css">
+    </head>
+    <body>
+        <p><h1>${GITHUB_REPOSITORY_OWNER}&#39;s package index</h1></p>
+        <p><h2>${pkgname} ${pkgver}-${pkgrel}</h2></p>
+        
+        <p>
+            <b>Architecture:</b> ${ARCH}</br>
+            <b>Description:</b> ${pkgdesc}</br>
+            <b>Upstream URL:</b> <a href="${url}">${url}</a></br>
+            <b>License:</b> ${LICENSE}</br>
+            <b>Package Size:</b> ${PKGSIZE}</br>
+            <b>Installed Size:</b> ${INSTSIZE}</br>
+            <b>Download:</b> <a href="${DOWNLOAD_URL}">${DOWNLOAD_URL}</a></br>
+        </p>
+
+        <p><h3>Dependencies</h3></p>
+        <p>${DEPS}</p>
+
+        <p><h3>Contents</h3></p>
+        <p>${CONTENT}</p>
+
+        <p><a href="index.html">Back to index</a></p>
+
+        <p>Source on <a href="https://github.com/${GITHUB_REPOSITORY}/">GitHub</a></p>
+    </body>
+</html>

--- a/package.html
+++ b/package.html
@@ -13,6 +13,7 @@
             <b>Description:</b> ${pkgdesc}</br>
             <b>Upstream URL:</b> <a href="${url}">${url}</a></br>
             <b>License:</b> ${LICENSE}</br>
+            <b>Last Updated:</b> ${UPDATED}</br>
             <b>Package Size:</b> ${PKGSIZE}</br>
             <b>Installed Size:</b> ${INSTSIZE}</br>
             <b>Download:</b> <a href="${DOWNLOAD_URL}">${DOWNLOAD_URL}</a></br>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,24 @@
+body {
+    font-family: sans-serif;
+}
+
+table {
+    border-collapse: collapse;
+    font-size: 0.9em;
+}
+
+table tbody tr {
+    border-bottom: 1px solid #dddddd;
+}
+
+table th, td {
+    padding: 12px 15px;
+}
+
+table tbody tr:nth-of-type(even) {
+    background-color: #f3f3f3;
+}
+
+table tbody tr:nth-of-type(uneven) {
+    background-color: #009879;
+}


### PR DESCRIPTION
This adds an index page and a page for each package with info on them to the github pages where we host the repository like mentioned in https://github.com/pspdev/psp-packages/issues/155. I used the scripts there as an example to build this. This is some very basic html, filled using environment variables and envsubst. You can see the result here: https://sharkwouter.github.io/psp-packages/

I also added an empty style.css file. So if someone feels like making this look better, then can get started immediately after this has been merged.