### PR TITLE
Add all current packages to pspdev-default group

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.zip
 *.bz2
 __pycache__/
+repo/
 
 # do allow github workflow files
 !.github/workflows/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,6 +30,7 @@ For new contributions to be merged, the PSPBUILDs in them should meet the follow
   - The license of the library should be installed in ``$pkgdir/psp/share/licenses/$pkgname/``.
   - PSPBUILDs which use a git repository as source should use a specific tag or commit.
   - ``pkgname`` should not contain capital letters or special characters other than ``-``.
+  - ``groups`` should be set if to ``pspdev-default`` unless the package conflicts with an existing package.
 - For existing packages:
   - Either the ``pkgver`` or ``rel`` has been changed.
 - For all PSPBUILDs:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_DOCKER_IMAGE
 FROM $BASE_DOCKER_IMAGE
 
 RUN psp-pacman -Sy && \
-    yes | psp-pacman -S $(psp-pacman -Slq) && \
+    yes | psp-pacman -S pspdev-default && \
     yes | psp-pacman -Scc && \
     cd /usr/local/pspdev && tree
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,8 @@ ARG BASE_DOCKER_IMAGE
 FROM $BASE_DOCKER_IMAGE
 
 RUN psp-pacman -Sy && \
-    yes | psp-pacman -S pspdev-default && \
-    yes | psp-pacman -Scc && \
+    psp-pacman -S --noconfirm pspdev-default && \
+    psp-pacman -Scc --noconfirm && \
     cd /usr/local/pspdev && tree
 
 # Second stage of Dockerfile

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Installing all available libraries can be done with:
 
 ```
 psp-pacman -Sy
-psp-pacman -S $(psp-pacman -Slq)
+psp-pacman -S pspdev-default
 ```
 
 Updating libraries can be done with:

--- a/angelscript/PSPBUILD
+++ b/angelscript/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=angelscript
 pkgver=2.28.2
-pkgrel=1
+pkgrel=2
 pkgdesc="A game-oriented interpreted compiled scripting language library"
 arch=('mips')
 url="http://angelcode.com/angelscript/"
 license=('ZLIB')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/argtable2/PSPBUILD
+++ b/argtable2/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=argtable2
 pkgver=13
-pkgrel=2
+pkgrel=3
 pkgdesc="Argtable is an ANSI C library for parsing GNU style command line options with a minimum of fuss"
 arch=('mips')
 url="http://argtable.sourceforge.net/"
 license=('GPL2')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/bzip2/PSPBUILD
+++ b/bzip2/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=bzip2
 pkgver=1.0.8
-pkgrel=3
+pkgrel=4
 pkgdesc="A high-quality data compression library"
 arch=('mips')
 url="http://www.sourceware.org/bzip2/"
 license=('custom')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/cjson/PSPBUILD
+++ b/cjson/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=cjson
 pkgver=1.7.16
-pkgrel=1
+pkgrel=2
 pkgdesc="Ultralightweight JSON parser in ANSI C."
 arch=('mips')
 url="https://github.com/DaveGamble/cJSON/"
 license=('MIT')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/curl/PSPBUILD
+++ b/curl/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=curl
 pkgver=7.64.1
-pkgrel=7
+pkgrel=8
 pkgdesc="A library for transferring data with URL syntax"
 arch=('mips')
 url="https://curl.se/"
 license=('custom')
+groups=('pspdev-default')
 depends=('zlib' 'mbedtls')
 optdepends=()
 makedepends=()

--- a/dumb/PSPBUILD
+++ b/dumb/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=dumb
 pkgver=2.0.3
-pkgrel=2
+pkgrel=3
 pkgdesc="Dynamic Universal Music Bibliotheque - DUMB - Module/tracker based music format parser and player library"
 arch=('mips')
 url="https://github.com/kode54/dumb"
 license=('GPL2')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/enet/PSPBUILD
+++ b/enet/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=enet
 pkgver=1.3.18
-pkgrel=1
+pkgrel=2
 pkgdesc="ENet reliable UDP networking library"
 arch=('mips')
 url="http://enet.bespin.org/"
 license=('MIT')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/expat/PSPBUILD
+++ b/expat/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=expat
 pkgver=2.4.1
-pkgrel=3
+pkgrel=4
 pkgdesc="XML parsing C library"
 arch=('mips')
 url="https://libexpat.github.io/"
 license=('MIT')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/freetype2/PSPBUILD
+++ b/freetype2/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=freetype2
 pkgver=2.11.0
-pkgrel=3
+pkgrel=4
 pkgdesc="a freely available software library to render fonts"
 arch=('mips')
 url="https://www.freetype.org/"
 license=('custom:Freetype' 'GPL2')
+groups=('pspdev-default')
 depends=('zlib' 'bzip2' 'libpng')
 makedepends=()
 optdepends=()

--- a/glm/PSPBUILD
+++ b/glm/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=glm
 pkgver=0.9.9
-pkgrel=1
+pkgrel=2
 pkgdesc="OpenGL Mathematics (GLM) is a header only C++ mathematics library for graphics software based on the OpenGL Shading Language (GLSL) specifications."
 arch=('mips')
 url="https://glm.g-truc.net/"
 license=('MIT')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/googletest/PSPBUILD
+++ b/googletest/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=googletest
 pkgver=1.14.0
-pkgrel=1
+pkgrel=2
 pkgdesc="GoogleTest - Google Testing and Mocking Framework"
 arch=('mips')
 url="google.github.io/googletest/"
 license=('BSD-3-Clause')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/harfbuzz/PSPBUILD
+++ b/harfbuzz/PSPBUILD
@@ -1,11 +1,12 @@
 pkgname=harfbuzz
 pkgver=8.5.0
-pkgrel=1
+pkgrel=2
 pkgdesc="OpenType text shaping engine"
 arch=('mips')
 url="https://harfbuzz.github.io/"
 license=('MIT')
 depends=('freetype2')
+groups=('pspdev-default')
 makedepends=()
 optdepends=()
 source=(

--- a/index.html
+++ b/index.html
@@ -7,7 +7,7 @@
     <body>
         <p><h1>${GITHUB_REPOSITORY_OWNER}&#39;s package index</h1></p>
         <table>
-            <tr><th>Name</th><th>Version</th><th>Description</th><th>Last Updated</th></tr>
+            <tr><th>Name</th><th>Version</th><th>Description</th><th>Groups</th><th>Last Updated</th></tr>
             ${INDEX_TABLE_CONTENT}
         </table>
         <p>Source on <a href="https://github.com/${GITHUB_REPOSITORY}/">GitHub</a></p>

--- a/jpeg/PSPBUILD
+++ b/jpeg/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=jpeg
 pkgver=3.0.3
-pkgrel=4
+pkgrel=5
 pkgdesc="a free library for JPEG image compression"
 arch=('mips')
 url="https://ijg.org/"
 license=('custom')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/jsoncpp/PSPBUILD
+++ b/jsoncpp/PSPBUILD
@@ -1,9 +1,10 @@
 pkgname=jsoncpp
 pkgver=1.9.5
-pkgrel=2
+pkgrel=3
 pkgdesc="a C++ library for interacting with JSON"
 arch=('mips')
 license=('unlicense')
+groups=('pspdev-default')
 url="https://github.com/open-source-parsers/jsoncpp"
 makedepends=()
 source=("git+https://github.com/open-source-parsers/jsoncpp#commit=5defb4ed1a4293b8e2bf641e16b156fb9de498cc")

--- a/kubridge/PSPBUILD
+++ b/kubridge/PSPBUILD
@@ -1,9 +1,10 @@
 pkgname=kubridge
 pkgver=20240427
-pkgrel=1
+pkgrel=2
 pkgdesc="a bridging library to provide Kernel functions for PSPs in User Mode"
 arch=('mips')
 license=('GPL2')
+groups=('pspdev-default')
 url="https://github.com/pspdev/kubridge"
 makedepends=()
 source=("git+https://github.com/pspdev/${pkgname}#commit=370b753145509578a1d4697eb50e8e9912d75679")

--- a/leptonica/PSPBUILD
+++ b/leptonica/PSPBUILD
@@ -1,11 +1,12 @@
 pkgname=leptonica
 pkgver=1.84.1
-pkgrel=3
+pkgrel=4
 pkgdesc="An open source C library for efficient image processing and image analysis operations"
 arch=('mips')
 url="http://www.leptonica.org/"
 license=('BSD-2-Clause')
 depends=('zlib' 'libpng' 'jpeg')
+groups=('pspdev-default')
 makedepends=()
 optdepends=()
 source=(

--- a/libbulletml/PSPBUILD
+++ b/libbulletml/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=libbulletml
 pkgver=0.0.5
-pkgrel=2
+pkgrel=3
 pkgdesc="Bullet Markup Language for PSP"
 arch=('mips')
 url="https://www.asahi-net.or.jp/~cs8k-cyu/bulletml/index_e.html"
 license=('BSD')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/libconfuse/PSPBUILD
+++ b/libconfuse/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=libconfuse
 pkgver=3.3
-pkgrel=3
+pkgrel=4
 pkgdesc="Small configuration file parser library for C"
 arch=('mips')
 url="https://github.com/libconfuse/libconfuse/"
 license=('MIT')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/libeigen/PSPBUILD
+++ b/libeigen/PSPBUILD
@@ -1,9 +1,10 @@
 pkgname=libeigen
 pkgver=3.4.0
+pkgrel=2
 url="http://eigen.tuxfamily.org"
 source=("https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-$pkgver.tar.gz")
 license=('BSD')
-pkgrel=1
+groups=('pspdev-default')
 depends=()
 makedepends=()
 pkgdesc="C++ template library for linear algebra: matrices, vectors, numerical solvers, and related algorithms"

--- a/libintrafont/PSPBUILD
+++ b/libintrafont/PSPBUILD
@@ -1,9 +1,10 @@
 pkgname=libintrafont
 pkgver=4.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A bitmap font library using the PSP's internal fonts (firmware pgf and bwfon files)"
 arch=('mips')
 license=('cc-by-sa-3.0')
+groups=('pspdev-default')
 url="https://github.com/pspdev/libintrafont"
 makedepends=()
 source=("git+https://github.com/pspdev/${pkgname}#commit=acbb1617327b9e453f5a9e3307b4dae20ca68f7d")

--- a/libmad/PSPBUILD
+++ b/libmad/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=libmad
 pkgver=0.15.1
-pkgrel=3
+pkgrel=4
 pkgdesc="MPEG audio decoder library for PSP"
 arch=('mips')
 url="https://www.underbit.com/products/mad"
 license=('GPL2')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/libmikmod/PSPBUILD
+++ b/libmikmod/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=libmikmod
 pkgver=3.3.11.1
-pkgrel=4
+pkgrel=5
 pkgdesc="a portable sound library capable of playing samples as well as module files"
 arch=('mips')
 url="http://mikmod.sourceforge.net/"
 license=('GPL2.1')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/libmodplug/PSPBUILD
+++ b/libmodplug/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=libmodplug
 pkgver=0.8.8.5
-pkgrel=1
+pkgrel=2
 pkgdesc="libmodplug - the library which was part of the Modplug-xmms project"
 arch=('mips')
 url="http://modplug-xmms.sf.net/"
 license=('public domain')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/libogg/PSPBUILD
+++ b/libogg/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=libogg
 pkgver=1.3.5
-pkgrel=2
+pkgrel=3
 pkgdesc="library for the multimedia container format, and the native file and stream format ogg"
 arch=('mips')
 url="https://www.xiph.org/ogg/"
 license=('BSD')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/libpng/PSPBUILD
+++ b/libpng/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=libpng
 pkgver=1.6.43
-pkgrel=5
+pkgrel=6
 pkgdesc="libpng is the official PNG reference library"
 arch=('mips')
 url="http://libpng.org/pub/png/libpng.html"
 license=('ZLIB')
+groups=('pspdev-default')
 depends=('zlib')
 makedepends=()
 optdepends=()

--- a/libpspexploit/PSPBUILD
+++ b/libpspexploit/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=libpspexploit
 pkgver=1.2
-pkgrel=3
+pkgrel=4
 pkgdesc="LibPspExploit is a library that allows creating OFW-compatible homebrew with kernel access."
 arch=('mips')
 url="https://github.com/PSP-Archive/LibPspExploit/"
 license=('WTFPL')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/libpspvram/PSPBUILD
+++ b/libpspvram/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=libpspvram
 pkgver=r11.885fd3f
-pkgrel=1
+pkgrel=2
 pkgdesc="Dynamic VRAM allocation manager for the PSP"
 arch=('mips')
 url="https://github.com/albe/libpspvram"
 license=('MIT')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/libun7zip/PSPBUILD
+++ b/libun7zip/PSPBUILD
@@ -1,9 +1,10 @@
 pkgname=libun7zip
 pkgver=19.00
-pkgrel=2
+pkgrel=3
 pkgdesc="A library that provides 7-Zip (.7z) archive handling and extraction"
 arch=('mips')
 license=('Apache-2.0 license')
+groups=('pspdev-default')
 url="https://github.com/bucanero/libun7zip"
 makedepends=()
 source=("git+https://github.com/bucanero/${pkgname}#commit=23e7cecd979fd893a6a7d3fcc51b2478cd860607")

--- a/libvorbis/PSPBUILD
+++ b/libvorbis/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=libvorbis
 pkgver=1.3.7
-pkgrel=2
+pkgrel=3
 pkgdesc="Vorbis audio compression reference implementation"
 arch=('mips')
 url="https://gitlab.xiph.org/xiph/vorbis"
 license=('BSD')
+groups=('pspdev-default')
 depends=('libogg')
 makedepends=()
 optdepends=()

--- a/libxmp-lite/PSPBUILD
+++ b/libxmp-lite/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=libxmp-lite
 pkgver=4.6.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Libxmp is a library that renders module files to PCM data"
 arch=('mips')
 url="https://github.com/libxmp/libxmp"
 license=('MIT')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/libxmp/PSPBUILD
+++ b/libxmp/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=libxmp
 pkgver=4.5.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Libxmp is a library that renders module files to PCM data"
 arch=('mips')
 url="https://github.com/libxmp/libxmp"
 license=('GPL2')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/libyaml/PSPBUILD
+++ b/libyaml/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=libyaml
 pkgver=0.2.5
-pkgrel=1
+pkgrel=2
 pkgdesc="LibYAML is a YAML parser and emitter library"
 arch=('mips')
 url="https://pyyaml.org/wiki/LibYAML"
 license=('MIT')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/libzip/PSPBUILD
+++ b/libzip/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=libzip
 pkgver=1.9.2
-pkgrel=1
+pkgrel=2
 pkgdesc="libzip is a C library for reading, creating, and modifying zip archives."
 arch=('mips')
 url="https://libzip.org/"
 license=('3-clause BSD license')
+groups=('pspdev-default')
 depends=('zlib' 'bzip2')
 makedepends=()
 optdepends=()

--- a/lua/PSPBUILD
+++ b/lua/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=lua
 pkgver=5.2
-pkgrel=2
+pkgrel=3
 pkgdesc="Lua programming language for PSP"
 arch=('mips')
 url="https://lua.org"
 license=('MIT')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/lua51/PSPBUILD
+++ b/lua51/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=lua51
 pkgver=5.1.5
-pkgrel=2
+pkgrel=3
 pkgdesc="Lua programming language for PSP"
 arch=('mips')
 url="https://lua.org"
 license=('MIT')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/make-repo-html.sh
+++ b/make-repo-html.sh
@@ -2,6 +2,7 @@
 
 #Change directory to the directory of this script
 cd "$(dirname "$0")"
+mkdir -p repo
 
 # Export all variables
 set -a
@@ -23,6 +24,7 @@ for PSPBUILD in $(find . -name "PSPBUILD" | sort); do
 		# Convert lists to strings
 		ARCH="${arch[*]}"
 		LICENSE="${license[*]}"
+		GROUP_LIST="${groups[*]}"
 
 		# Get file size info
 		FILENAME="repo/${DOWNLOAD_URL}"
@@ -55,7 +57,7 @@ for PSPBUILD in $(find . -name "PSPBUILD" | sort); do
 
 		envsubst < package.html > "repo/${pkgname}.html"
 
-		INDEX_TABLE_CONTENT="${INDEX_TABLE_CONTENT}<tr><td><a href=\"${pkgname}.html\">${pkgname}</a></td><td>${pkgver}-${pkgrel}</td><td>${pkgdesc}</td><td>${UPDATED}</td></tr>"
+		INDEX_TABLE_CONTENT="${INDEX_TABLE_CONTENT}<tr><td><a href=\"${pkgname}.html\">${pkgname}</a></td><td>${pkgver}-${pkgrel}</td><td>${pkgdesc}</td><td>${GROUP_LIST}</td><td>${UPDATED}</td></tr>"
 done
 
 envsubst < index.html > repo/index.html

--- a/mbedtls/PSPBUILD
+++ b/mbedtls/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=mbedtls
 pkgver=2.16.12
-pkgrel=1
+pkgrel=2
 pkgdesc="Secure Socket Layer library"
 arch=('mips')
 url="https://www.trustedfirmware.org/projects/mbed-tls/"
 license=('Apache 2.0 license')
+groups=('pspdev-default')
 depends=()
 optdepends=()
 makedepends=()

--- a/mini18n/PSPBUILD
+++ b/mini18n/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=mini18n
 pkgver=0.2.1
-pkgrel=1
+pkgrel=2
 pkgdesc="mini18n is a translation library under GNU GPL."
 arch=('mips')
 url="https://github.com/bucanero/mini18n/"
 license=('GPL 2.0')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/minizip/PSPBUILD
+++ b/minizip/PSPBUILD
@@ -1,9 +1,11 @@
 pkgname=minizip
 pkgver=3.0.4
-pkgrel=2
+pkgrel=3
 pkgdesc="fork of the popular zip manipulation library found in the zlib distribution"
 arch=('mips')
 url="https://github.com/zlib-ng/minizip-ng"
+license=('zlib')
+groups=('pspdev-default')
 depends=('zlib' 'bzip2')
 makedepends=()
 optdepends=()

--- a/openal/PSPBUILD
+++ b/openal/PSPBUILD
@@ -1,9 +1,10 @@
 pkgname=openal
 pkgver=1.23.1
-pkgrel=1
+pkgrel=2
 pkgdesc="a cross-platform 3D audio API"
 arch=('mips')
 license=('LGPL-2.0')
+groups=('pspdev-default')
 url="https://openal-soft.org/"
 makedepends=()
 source=("https://github.com/kcat/openal-soft/releases/download/${pkgver}/openal-soft-${pkgver}.tar.bz2")

--- a/opentri/PSPBUILD
+++ b/opentri/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=opentri
 pkgver=r7.95b040d
-pkgrel=4
+pkgrel=5
 pkgdesc="openTRI is a game engine for the PSP"
 arch=('mips')
 url="https://github.com/fjtrujy/openTRI"
 license=('GPL2')
+groups=('pspdev-default')
 depends=('zlib' 'freetype2')
 makedepends=()
 optdepends=()

--- a/package.html
+++ b/package.html
@@ -13,6 +13,7 @@
             <b>Description:</b> ${pkgdesc}</br>
             <b>Upstream URL:</b> <a href="${url}">${url}</a></br>
             <b>License:</b> ${LICENSE}</br>
+            <b>Groups:</b> ${GROUP_LIST}</br>
             <b>Last Updated:</b> ${UPDATED}</br>
             <b>Package Size:</b> ${PKGSIZE}</br>
             <b>Installed Size:</b> ${INSTSIZE}</br>

--- a/pixman/PSPBUILD
+++ b/pixman/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=pixman
 pkgver=0.40.0
-pkgrel=4
+pkgrel=5
 pkgdesc="Pixman is a low-level software library for pixel manipulation"
 arch=('mips')
 url="http://pixman.org/"
 license=('MIT')
+groups=('pspdev-default')
 depends=('libpng')
 makedepends=()
 optdepends=()

--- a/pocketpy/PSPBUILD
+++ b/pocketpy/PSPBUILD
@@ -1,9 +1,10 @@
 pkgname=pocketpy
 pkgver=1.4.5
-pkgrel=1
+pkgrel=2
 pkgdesc="Python interpreter for game scripting"
 arch=('mips')
 license=('MIT')
+groups=('pspdev-default')
 url="https://pocketpy.dev/"
 makedepends=()
 source=("https://github.com/pocketpy/pocketpy/archive/refs/tags/v${pkgver}.tar.gz")

--- a/polarssl/PSPBUILD
+++ b/polarssl/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=polarssl
 pkgver=1.3.9
-pkgrel=2
+pkgrel=3
 pkgdesc="Secure Socket Layer library"
 arch=('mips')
 url="https://www.trustedfirmware.org/projects/mbed-tls/"
 license=('GPL2')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/pspgl/PSPBUILD
+++ b/pspgl/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=pspgl
 pkgver=r12
-pkgrel=3
+pkgrel=4
 pkgdesc="OpenGL-ESish library for PSP"
 arch=('mips')
 url="https://github.com/pspdev/pspgl"
 license=('BSD')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/pspirkeyb/PSPBUILD
+++ b/pspirkeyb/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=pspirkeyb
 pkgver=r1
-pkgrel=2
+pkgrel=3
 pkgdesc="a library for using IRDA keyboards with Playstation Portable"
 arch=('mips')
 url="https://github.com/pspdev/pspirkeyb"
 license=('LGPL2.1')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/pspla/PSPBUILD
+++ b/pspla/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=pspla
 pkgver=2.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="A VFPU accelerated linear algebra & quaternion library for PSP"
 arch=('mips')
 url="https://github.com/Jayanky/pspla"
 license=('MIT')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/pspuart/PSPBUILD
+++ b/pspuart/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=pspuart
 pkgver=r14.9bb4add
-pkgrel=1
+pkgrel=2
 pkgdesc="Library for PSP UART hardware communication (ex SioDriver)"
 arch=('mips')
 url="https://github.com/Operation-DITTO/psp-uart-library"
 license=('CC-BY-SA-4.0')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/sdl-gfx/PSPBUILD
+++ b/sdl-gfx/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=sdl-gfx
 pkgver=2.0.26
-pkgrel=2
+pkgrel=3
 pkgdesc="SDL graphics drawing primitives and other support functions"
 arch=('mips')
 url="https://www.ferzkopp.net/wordpress/2016/01/02/sdl_gfx-sdl2_gfx/"
 license=('ZLIB')
+groups=('pspdev-default')
 depends=('sdl' 'freetype2')
 makedepends=()
 optdepends=()

--- a/sdl-image/PSPBUILD
+++ b/sdl-image/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=sdl-image
 pkgver=1.2.13
-pkgrel=4
+pkgrel=5
 pkgdesc="a simple library to load images of various formats as SDL2 surfaces"
 arch=('mips')
 url="https://www.libsdl.org/projects/old/SDL_image/release-1.2.html"
 license=('ZLIB')
+groups=('pspdev-default')
 depends=('sdl' 'libpng' 'jpeg')
 makedepends=()
 optdepends=()

--- a/sdl-mixer/PSPBUILD
+++ b/sdl-mixer/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=sdl-mixer
 pkgver=1.2.14
-pkgrel=5
+pkgrel=6
 pkgdesc="an audio mixer library based on the SDL library"
 arch=('mips')
 url="https://www.libsdl.org/projects/old/SDL_mixer/release-1.2.html"
 license=('ZLIB')
+groups=('pspdev-default')
 depends=('sdl' 'libmikmod' 'libogg' 'libvorbis')
 makedepends=()
 optdepends=()

--- a/sdl-net/PSPBUILD
+++ b/sdl-net/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=sdl-net
 pkgver=1.2.9
-pkgrel=1
+pkgrel=2
 pkgdesc="a wrapper over TCP/IP sockets"
 arch=('mips')
 url="https://www.libsdl.org/projects/old/SDL_net/release-1.2.html"
 license=('ZLIB')
+groups=('pspdev-default')
 depends=('sdl')
 makedepends=()
 optdepends=()

--- a/sdl-ttf/PSPBUILD
+++ b/sdl-ttf/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=sdl-ttf
 pkgver=2.0.11
-pkgrel=4
+pkgrel=5
 pkgdesc="a companion library to SDL for working with TrueType (tm) fonts"
 arch=('mips')
 url="https://www.libsdl.org/projects/old/SDL_ttf/release-1.2.html"
 license=('ZLIB')
+groups=('pspdev-default')
 depends=('sdl' 'freetype2')
 makedepends=()
 optdepends=()

--- a/sdl/PSPBUILD
+++ b/sdl/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=sdl
 pkgver=1.2.15
-pkgrel=4
+pkgrel=5
 pkgdesc="a library designed to provide low level access to audio, input, and graphics hardware"
 arch=('mips')
 url="https://www.libsdl.org/download-1.2.php"
 license=('LGPL-2.1')
+groups=('pspdev-default')
 depends=('pspirkeyb')
 makedepends=()
 optdepends=()

--- a/sdl2-gfx/PSPBUILD
+++ b/sdl2-gfx/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=sdl2-gfx
 pkgver=1.0.4
-pkgrel=2
+pkgrel=3
 pkgdesc="SDL2 graphics drawing primitives and other support functions"
 arch=('mips')
 url="http://www.ferzkopp.net/wordpress/2016/01/02/sdl_gfx-sdl2_gfx/"
 license=('ZLIB')
+groups=('pspdev-default')
 depends=('sdl2')
 makedepends=()
 optdepends=()

--- a/sdl2-image/PSPBUILD
+++ b/sdl2-image/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=sdl2-image
 pkgver=2.6.3
-pkgrel=3
+pkgrel=4
 pkgdesc="a simple library to load images of various formats as SDL surfaces"
 arch=('mips')
 url="https://wiki.libsdl.org/SDL2_image/FrontPage"
 license=('ZLIB')
+groups=('pspdev-default')
 depends=('sdl2' 'libpng' 'jpeg')
 makedepends=()
 optdepends=()

--- a/sdl2-mixer/PSPBUILD
+++ b/sdl2-mixer/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=sdl2-mixer
 pkgver=2.6.3
-pkgrel=7
+pkgrel=8
 pkgdesc="an audio mixer library based on the SDL2 library"
 arch=('mips')
 url="https://wiki.libsdl.org/SDL2_mixer/FrontPage"
 license=('ZLIB')
+groups=('pspdev-default')
 depends=('sdl2' 'libmodplug' 'libvorbis' 'libogg')
 makedepends=()
 optdepends=()

--- a/sdl2-net/PSPBUILD
+++ b/sdl2-net/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=sdl2-net
 pkgver=2.2.0
-pkgrel=2
+pkgrel=3
 pkgdesc="a wrapper over TCP/IP sockets"
 arch=('mips')
 url="https://wiki.libsdl.org/SDL2_net/FrontPage"
 license=('ZLIB')
+groups=('pspdev-default')
 depends=('sdl2')
 makedepends=()
 optdepends=()

--- a/sdl2-ttf/PSPBUILD
+++ b/sdl2-ttf/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=sdl2-ttf
 pkgver=2.20.2
-pkgrel=3
+pkgrel=4
 pkgdesc="a companion library to SDL2 for working with TrueType (tm) fonts"
 arch=('mips')
 url="https://wiki.libsdl.org/SDL2_ttf/FrontPage"
 license=('ZLIB')
+groups=('pspdev-default')
 depends=('sdl2' 'harfbuzz')
 makedepends=()
 optdepends=()

--- a/sdl2/PSPBUILD
+++ b/sdl2/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=sdl2
 pkgver=2.30.4
-pkgrel=1
+pkgrel=2
 pkgdesc="a library designed to provide low level access to audio, input, and graphics hardware"
 arch=('mips')
 url="https://wiki.libsdl.org/SDL2/FrontPage"
 license=('ZLIB')
+groups=('pspdev-default')
 depends=('libpspvram' 'pspgl')
 makedepends=()
 optdepends=()

--- a/smpeg/PSPBUILD
+++ b/smpeg/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=smpeg
 pkgver=0.4.5
-pkgrel=2
+pkgrel=3
 pkgdesc="a free MPEG1 video player library with sound support"
 arch=('mips')
 url="https://github.com/fungos/smpeg-psp/"
 license=('LGPL2')
+groups=('pspdev-default')
 depends=('sdl')
 makedepends=()
 optdepends=()

--- a/sqlite/PSPBUILD
+++ b/sqlite/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=sqlite
 pkgver=3.7.4
-pkgrel=3
+pkgrel=4
 pkgdesc="SQLite is a C-language library that implements a small, fast, self-contained, high-reliability, full-featured, SQL database engine"
 arch=('mips')
 url="https://www.sqlite.org/"
 license=('custom:Public Domain')
+groups=('pspdev-default')
 depends=()
 optdepends=()
 makedepends=()

--- a/squirrel/PSPBUILD
+++ b/squirrel/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=squirrel
 pkgver=3.1.0
-pkgrel=1
+pkgrel=2
 pkgdesc="Runtime libraries for the Squirrel programming language"
 arch=('mips')
 url="http://squirrel-lang.org/"
 license=('custom')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/theora/PSPBUILD
+++ b/theora/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=theora
 pkgver=1.2.0git
-pkgrel=2
+pkgrel=3
 pkgdesc="Standard encoder and decoder library for the Theora video compression format"
 arch=('mips')
 url="https://www.theora.org/"
 license=('BSD')
+groups=('pspdev-default')
 depends=('libogg')
 makedepends=()
 optdepends=()

--- a/tremor/PSPBUILD
+++ b/tremor/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=tremor
 pkgver=1.2.1git
-pkgrel=1
+pkgrel=2
 pkgdesc="Integer-only, fully Ogg Vorbis compliant software decoder library"
 arch=('mips')
 url="https://wiki.xiph.org/Tremor"
 license=('BSD')
+groups=('pspdev-default')
 depends=('libogg')
 makedepends=()
 optdepends=()

--- a/wolfssl/PSPBUILD
+++ b/wolfssl/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=wolfssl
 pkgver=5.7.0
-pkgrel=2
+pkgrel=3
 pkgdesc="The wolfSSL library is a small, fast, portable implementation of TLS/SSL for embedded devices to the cloud. wolfSSL supports up to TLS 1.3!"
 arch=('mips')
 url="www.wolfssl.com"
 license=('GPL2')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/yaml-cpp/PSPBUILD
+++ b/yaml-cpp/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=yaml-cpp
 pkgver=0.8.0git
-pkgrel=1
+pkgrel=2
 pkgdesc=" A YAML parser and emitter in C++ "
 arch=('mips')
 url="https://github.com/jbeder/yaml-cpp"
 license=('MIT')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/zlib/PSPBUILD
+++ b/zlib/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=zlib
 pkgver=1.3.1
-pkgrel=3
+pkgrel=4
 pkgdesc="Compression library implementing the deflate compression method found in gzip and PKZIP"
 arch=('mips')
 url="https://www.zlib.net/"
 license=('ZLIB')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()

--- a/zziplib/PSPBUILD
+++ b/zziplib/PSPBUILD
@@ -1,10 +1,11 @@
 pkgname=zziplib
 pkgver=0.13.76
-pkgrel=1
+pkgrel=2
 pkgdesc="provides read access to zipped files in a zip-archive"
 arch=('mips')
 url="http://zziplib.sourceforge.net/"
 license=('ZLIB')
+groups=('pspdev-default')
 depends=('zlib')
 makedepends=()
 optdepends=()


### PR DESCRIPTION
This adds a group called `pspdev-default` which contains all current packages.

Using a group gives us the following benefits:
- It makes it easier to install all relevant packages with `psp-pacman -Sy pspdev-default`.
- Allow conflicting packages to exist in the repo. We just need to make sure they are not in the group.
- Allow us to exclude specific larger or niche packages from the prebuild toolchain.

I've also added the group to the index pages and updated the docker script. Here is what the index pages look like with this change: https://sharkwouter.github.io/psp-packages/