### PR TITLE
Unset lists which are not in every PSPBUILD

### DIFF
--- a/make-repo-html.sh
+++ b/make-repo-html.sh
@@ -17,6 +17,11 @@ INDEX_TABLE_CONTENT=""
 
 # Build the html pages
 for PSPBUILD in $(find . -name "PSPBUILD" | sort); do
+  		# Make sure optional variables are from current PSPBUILD
+  		unset groups
+    		unset license
+      		unset depends
+
 		source "${PSPBUILD}"
 		UPDATED=$(git log -1 --format=%cd --date=short -- "${PSPBUILD}")
 		DOWNLOAD_URL="${pkgname}-${pkgver}-${pkgrel}-${arch}.pkg.tar.gz"


### PR DESCRIPTION
Currently the index lists dependencies, licenses and groups from the last package if the variable does not exist in the current one.