### PR TITLE
add physfs package

### DIFF
--- a/physfs/PSPBUILD
+++ b/physfs/PSPBUILD
@@ -33,7 +33,7 @@ build() {
     mkdir pspbuild
     cd pspbuild
     psp-cmake .. -Wno-dev -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DPHYSFS_BUILD_TEST=Off \
-        -DPHYSFS_ARCHIVE_SLB=Off -DPHYSFS_BUILD_SHARED=Off -DPHYSFS_BUILD_DOCS=Off
+        -DPHYSFS_ARCHIVE_SLB=Off -DPHYSFS_BUILD_SHARED=Off -DPHYSFS_BUILD_DOCS=Off -DPHYSFS_ARCHIVE_ISO9660=Off
     make
 }
 

--- a/physfs/PSPBUILD
+++ b/physfs/PSPBUILD
@@ -1,0 +1,39 @@
+pkgname=physfs
+pkgver=3.2.0
+pkgrel=1
+pkgdesc="PhysicsFS; a portable, flexible file i/o abstraction."
+arch=('mips')
+url="https://icculus.org/physfs/"
+license=('Zlib')
+depends=()
+makedepends=()
+optdepends=()
+provides=()
+source=(
+"https://github.com/icculus/physfs/archive/refs/tags/release-${pkgver}.tar.gz"
+"psp.patch"
+)
+sha256sums=(
+"1991500eaeb8d5325e3a8361847ff3bf8e03ec89252b7915e1f25b3f8ab5d560"
+"SKIP"
+)
+
+prepare() {
+    cd ${pkgname}-release-${pkgver}
+    patch -p1 < ../psp.patch
+}
+
+build() {
+    cd ${pkgname}-release-${pkgver}
+    mkdir pspbuild
+    cd pspbuild
+    psp-cmake .. -Wno-dev -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DPHYSFS_BUILD_TEST=Off -DPHYSFS_ARCHIVE_SLB=Off
+    make
+}
+
+package() {
+    cd ${pkgname}-release-${pkgver}
+    make install -C pspbuild
+    mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
+    install -m 644 LICENSE.txt "$pkgdir/psp/share/licenses/$pkgname"
+}

--- a/physfs/PSPBUILD
+++ b/physfs/PSPBUILD
@@ -32,7 +32,8 @@ build() {
     cd ${pkgname}-release-${pkgver}
     mkdir pspbuild
     cd pspbuild
-    psp-cmake .. -Wno-dev -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DPHYSFS_BUILD_TEST=Off -DPHYSFS_ARCHIVE_SLB=Off -DPHYSFS_BUILD_SHARED=Off
+    psp-cmake .. -Wno-dev -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DPHYSFS_BUILD_TEST=Off \
+        -DPHYSFS_ARCHIVE_SLB=Off -DPHYSFS_BUILD_SHARED=Off -DPHYSFS_BUILD_DOCS=Off
     make
 }
 

--- a/physfs/PSPBUILD
+++ b/physfs/PSPBUILD
@@ -27,7 +27,7 @@ build() {
     cd ${pkgname}-release-${pkgver}
     mkdir pspbuild
     cd pspbuild
-    psp-cmake .. -Wno-dev -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DPHYSFS_BUILD_TEST=Off -DPHYSFS_ARCHIVE_SLB=Off
+    psp-cmake .. -Wno-dev -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DPHYSFS_BUILD_TEST=Off -DPHYSFS_ARCHIVE_SLB=Off -DPHYSFS_BUILD_SHARED=Off
     make
 }
 

--- a/physfs/psp.patch
+++ b/physfs/psp.patch
@@ -1,33 +1,8 @@
-diff --git a/src/physfs.c b/src/physfs.c
-index fdb1405..7eaa5ba 100644
---- a/src/physfs.c
-+++ b/src/physfs.c
-@@ -11,6 +11,10 @@
- #define __PHYSICSFS_INTERNAL__
- #include "physfs_internal.h"
- 
-+#ifdef __PSP__
-+#include <pthread.h>
-+#endif
-+
- #if defined(_MSC_VER)
- #include <stdarg.h>
- 
-@@ -1194,6 +1198,9 @@ static int doDeinit(void);
- 
- int PHYSFS_init(const char *argv0)
- {
-+    #ifdef __PSP__
-+    pthread_init();
-+    #endif
-     BAIL_IF(initialized, PHYSFS_ERR_IS_INITIALIZED, 0);
- 
-     if (!externalAllocator)
 diff --git a/src/physfs_platforms.h b/src/physfs_platforms.h
-index d4e4bfd..fbcb70a 100644
+index 1ac17d9..0a1d70e 100644
 --- a/src/physfs_platforms.h
 +++ b/src/physfs_platforms.h
-@@ -72,6 +72,11 @@
+@@ -72,6 +72,10 @@
  #elif defined(unix) || defined(__unix__)
  #  define PHYSFS_PLATFORM_UNIX 1
  #  define PHYSFS_PLATFORM_POSIX 1
@@ -35,7 +10,6 @@ index d4e4bfd..fbcb70a 100644
 +#  define PHYSFS_NO_CDROM_SUPPORT 1
 +#  define PHYSFS_PLATFORM_UNIX 1
 +#  define PHYSFS_PLATFORM_POSIX 1
-+#  define PHYSFS_PLATFORM_PSP 1
  #else
  #  error Unknown platform.
  #endif

--- a/physfs/psp.patch
+++ b/physfs/psp.patch
@@ -1,0 +1,41 @@
+diff --git a/src/physfs.c b/src/physfs.c
+index fdb1405..7eaa5ba 100644
+--- a/src/physfs.c
++++ b/src/physfs.c
+@@ -11,6 +11,10 @@
+ #define __PHYSICSFS_INTERNAL__
+ #include "physfs_internal.h"
+ 
++#ifdef __PSP__
++#include <pthread.h>
++#endif
++
+ #if defined(_MSC_VER)
+ #include <stdarg.h>
+ 
+@@ -1194,6 +1198,9 @@ static int doDeinit(void);
+ 
+ int PHYSFS_init(const char *argv0)
+ {
++    #ifdef __PSP__
++    pthread_init();
++    #endif
+     BAIL_IF(initialized, PHYSFS_ERR_IS_INITIALIZED, 0);
+ 
+     if (!externalAllocator)
+diff --git a/src/physfs_platforms.h b/src/physfs_platforms.h
+index d4e4bfd..fbcb70a 100644
+--- a/src/physfs_platforms.h
++++ b/src/physfs_platforms.h
+@@ -72,6 +72,11 @@
+ #elif defined(unix) || defined(__unix__)
+ #  define PHYSFS_PLATFORM_UNIX 1
+ #  define PHYSFS_PLATFORM_POSIX 1
++#elif defined(PSP)
++#  define PHYSFS_NO_CDROM_SUPPORT 1
++#  define PHYSFS_PLATFORM_UNIX 1
++#  define PHYSFS_PLATFORM_POSIX 1
++#  define PHYSFS_PLATFORM_PSP 1
+ #else
+ #  error Unknown platform.
+ #endif


### PR DESCRIPTION
I'll take the initial port of physfs but the patch is credit to @stdgregwar 

- update to 3.2.0

this is the code i used to test

```c
-- snip the callback part --

int main(void)
{
    SetupCallbacks();
    pspDebugScreenInit();

    const char *filename = "test.txt";

    PHYSFS_init(NULL); // argv[0] is fine
    PHYSFS_mount(".", NULL, 1);
    PHYSFS_File *file = PHYSFS_openRead(filename);
    PHYSFS_sint64 fileSize = PHYSFS_fileLength(file);
    char *buffer = (char *)malloc(fileSize + 1);
    size_t bytesRead = PHYSFS_readBytes(file, buffer, fileSize);

    pspDebugScreenSetXY(0, 5);
    while (!done)
    {
        //Null-terminate the buffer
        buffer[bytesRead] = '\0';

        //Print the file contents
        pspDebugScreenPrintf("File contents: %s\n", buffer);
        pspDebugScreenPrintf("Error: %s\n", PHYSFS_getErrorByCode(PHYSFS_getLastErrorCode()));
    }

    sceKernelExitGame();
    return 0;
}
```
