### PR TITLE
Add physfs to pspdev-default group

### DIFF
--- a/physfs/PSPBUILD
+++ b/physfs/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=physfs
 pkgver=3.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="PhysicsFS; a portable, flexible file i/o abstraction."
 arch=('mips')
 url="https://icculus.org/physfs/"

--- a/physfs/PSPBUILD
+++ b/physfs/PSPBUILD
@@ -5,6 +5,7 @@ pkgdesc="PhysicsFS; a portable, flexible file i/o abstraction."
 arch=('mips')
 url="https://icculus.org/physfs/"
 license=('Zlib')
+groups=('pspdev-default')
 depends=()
 makedepends=()
 optdepends=()


### PR DESCRIPTION
This will make it be part of the prebuild toolchain. Currently users would have to manually install it to get it.