### PR TITLE
sdl2: update to version 2.30.10

### DIFF
--- a/sdl2/PSPBUILD
+++ b/sdl2/PSPBUILD
@@ -1,5 +1,5 @@
 pkgname=sdl2
-pkgver=2.30.9
+pkgver=2.30.10
 pkgrel=1
 pkgdesc="a library designed to provide low level access to audio, input, and graphics hardware"
 arch=('mips')
@@ -14,26 +14,24 @@ source=(
     "https://github.com/libsdl-org/SDL/releases/download/release-${pkgver}/SDL2-${pkgver}.tar.gz"
     "CMakeLists.txt.sample"
     "main.c.sample"
-    "https://github.com/libsdl-org/SDL/pull/11521.patch"
 )
 sha256sums=(
-    "24b574f71c87a763f50704bbb630cbe38298d544a1f890f099a4696b1d6beba4"
+    "f59adf36a0fcf4c94198e7d3d776c1b3824211ab7aeebeb31fe19836661196aa"
     "SKIP"
     "SKIP"
-    "dd22979f536ddeed243902d8ecd3b94253fdbe31d2fafa51d79f9802f96e83d8"
 )
 
 prepare() {
     cd "${srcdir}/SDL2-${pkgver}"
     sed -i '/^prefix=/s/=.*$/=${PSPDEV}\/psp/' sdl2.pc.in
-    patch -p1 < "${srcdir}/11521.patch"
 }
 
 build() {
     cd "${srcdir}/SDL2-${pkgver}"
     mkdir -p build && cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE="${PSPDEV}/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX=/psp \
-        -DBUILD_SHARED_LIBS=OFF -DSDL_TESTS=OFF -DSDL_TEST=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DBUILD_SHARED_LIBS=OFF -DSDL_TESTS=OFF -DSDL_TEST=OFF "${XTRA_OPTS[@]}" -DCMAKE_BUILD_TYPE=Release \
+        .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 


### PR DESCRIPTION
This also makes it a release build, which should speed up execution and make eboots smaller.