### PR TITLE
Build cmake based libraries in release mode

### DIFF
--- a/angelscript/PSPBUILD
+++ b/angelscript/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=angelscript
 pkgver=2.28.2
-pkgrel=2
+pkgrel=3
 pkgdesc="A game-oriented interpreted compiled scripting language library"
 arch=('mips')
 url="http://angelcode.com/angelscript/"
@@ -28,7 +28,7 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
-        "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/argtable2/PSPBUILD
+++ b/argtable2/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=argtable2
 pkgver=13
-pkgrel=3
+pkgrel=4
 pkgdesc="Argtable is an ANSI C library for parsing GNU style command line options with a minimum of fuss"
 arch=('mips')
 url="http://argtable.sourceforge.net/"
@@ -24,7 +24,7 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
-        "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/bzip2/PSPBUILD
+++ b/bzip2/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=bzip2
 pkgver=1.0.8
-pkgrel=4
+pkgrel=5
 pkgdesc="A high-quality data compression library"
 arch=('mips')
 url="http://www.sourceware.org/bzip2/"
@@ -26,7 +26,7 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
-        -DENABLE_SHARED_LIB=OFF -DENABLE_STATIC_LIB=ON -DENABLE_LIB_ONLY=ON "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DENABLE_SHARED_LIB=OFF -DENABLE_STATIC_LIB=ON -DENABLE_LIB_ONLY=ON -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/cjson/PSPBUILD
+++ b/cjson/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=cjson
 pkgver=1.7.16
-pkgrel=2
+pkgrel=3
 pkgdesc="Ultralightweight JSON parser in ANSI C."
 arch=('mips')
 url="https://github.com/DaveGamble/cJSON/"
@@ -24,7 +24,8 @@ prepare() {
 build() {
     cd "cJSON-$pkgver/build"
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
-        -DENABLE_CJSON_UTILS=On -DENABLE_LOCALES=OFF -DENABLE_CJSON_TEST=OFF -DENABLE_TARGET_EXPORT=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DENABLE_CJSON_UTILS=On -DENABLE_LOCALES=OFF -DENABLE_CJSON_TEST=OFF -DENABLE_TARGET_EXPORT=OFF -DCMAKE_BUILD_TYPE=Release \
+        "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/curl/PSPBUILD
+++ b/curl/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=curl
 pkgver=7.64.1
-pkgrel=8
+pkgrel=9
 pkgdesc="A library for transferring data with URL syntax"
 arch=('mips')
 url="https://curl.se/"
@@ -30,7 +30,8 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DCMAKE_USE_MBEDTLS=1 -DUSE_UNIX_SOCKETS=0 \
-         -DENABLE_IPV6=0 -DENABLE_THREADED_RESOLVER=0 -DBUILD_CURL_EXE=OFF -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DENABLE_IPV6=0 -DENABLE_THREADED_RESOLVER=0 -DBUILD_CURL_EXE=OFF -DBUILD_SHARED_LIBS=OFF -DBUILD_TESTING=OFF -DCMAKE_BUILD_TYPE=Release \
+        "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/enet/PSPBUILD
+++ b/enet/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=enet
 pkgver=1.3.18
-pkgrel=2
+pkgrel=3
 pkgdesc="ENet reliable UDP networking library"
 arch=('mips')
 url="http://enet.bespin.org/"
@@ -23,7 +23,7 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
-        "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/freetype2/PSPBUILD
+++ b/freetype2/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=freetype2
 pkgver=2.11.0
-pkgrel=4
+pkgrel=5
 pkgdesc="a freely available software library to render fonts"
 arch=('mips')
 url="https://www.freetype.org/"
@@ -26,7 +26,7 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=/psp -DBUILD_SHARED_LIBS=OFF \
-        "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/harfbuzz/PSPBUILD
+++ b/harfbuzz/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=harfbuzz
 pkgver=8.5.0
-pkgrel=2
+pkgrel=3
 pkgdesc="OpenType text shaping engine"
 arch=('mips')
 url="https://harfbuzz.github.io/"
@@ -34,7 +34,7 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
-        -DHB_HAVE_FREETYPE=ON "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DCMAKE_BUILD_TYPE=Release -DHB_HAVE_FREETYPE=ON "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/libmikmod/PSPBUILD
+++ b/libmikmod/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=libmikmod
 pkgver=3.3.11.1
-pkgrel=5
+pkgrel=6
 pkgdesc="a portable sound library capable of playing samples as well as module files"
 arch=('mips')
 url="http://mikmod.sourceforge.net/"
@@ -25,7 +25,7 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DENABLE_SHARED=0 \
-        "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/libmodplug/PSPBUILD
+++ b/libmodplug/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=libmodplug
 pkgver=0.8.8.5
-pkgrel=2
+pkgrel=3
 pkgdesc="libmodplug - the library which was part of the Modplug-xmms project"
 arch=('mips')
 url="http://modplug-xmms.sf.net/"
@@ -21,7 +21,7 @@ build() {
     cd libmodplug
     mkdir pspbuild
     cd pspbuild
-    psp-cmake .. -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp
+    psp-cmake .. -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DCMAKE_BUILD_TYPE=Release
     make
 }
 

--- a/libogg/PSPBUILD
+++ b/libogg/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=libogg
 pkgver=1.3.5
-pkgrel=3
+pkgrel=4
 pkgdesc="library for the multimedia container format, and the native file and stream format ogg"
 arch=('mips')
 url="https://www.xiph.org/ogg/"
@@ -25,7 +25,7 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
-        "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
     cd ../..
 }

--- a/libpng/PSPBUILD
+++ b/libpng/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=libpng
 pkgver=1.6.43
-pkgrel=6
+pkgrel=7
 pkgdesc="libpng is the official PNG reference library"
 arch=('mips')
 url="http://libpng.org/pub/png/libpng.html"
@@ -25,7 +25,7 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=/psp -DBUILD_SHARED_LIBS=OFF \
-        -DPNG_SHARED=OFF -DPNG_STATIC=ON -DUNIX=ON "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DPNG_SHARED=OFF -DPNG_STATIC=ON -DUNIX=ON -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/libpspvram/PSPBUILD
+++ b/libpspvram/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=libpspvram
 pkgver=r11.885fd3f
-pkgrel=2
+pkgrel=3
 pkgdesc="Dynamic VRAM allocation manager for the PSP"
 arch=('mips')
 url="https://github.com/albe/libpspvram"
@@ -22,7 +22,8 @@ build() {
     cd "$pkgname"
     mkdir -p build
     cd build
-    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp "${XTRA_OPTS[@]}" .. || { exit 1; }
+    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp \
+        -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/libvorbis/PSPBUILD
+++ b/libvorbis/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=libvorbis
 pkgver=1.3.7
-pkgrel=3
+pkgrel=4
 pkgdesc="Vorbis audio compression reference implementation"
 arch=('mips')
 url="https://gitlab.xiph.org/xiph/vorbis"
@@ -25,7 +25,7 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
-        -DUNIX:BOOL=ON "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DUNIX:BOOL=ON -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/libxmp-lite/PSPBUILD
+++ b/libxmp-lite/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=libxmp-lite
 pkgver=4.6.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Libxmp is a library that renders module files to PCM data"
 arch=('mips')
 url="https://github.com/libxmp/libxmp"
@@ -23,7 +23,7 @@ build() {
     cd "${srcdir}/${pkgname}-${pkgver}"
     mkdir -p build && cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE="${PSPDEV}/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX=/psp -DBUILD_SHARED=OFF \
-        "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/libxmp/PSPBUILD
+++ b/libxmp/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=libxmp
 pkgver=4.5.0
-pkgrel=3
+pkgrel=4
 pkgdesc="Libxmp is a library that renders module files to PCM data"
 arch=('mips')
 url="https://github.com/libxmp/libxmp"
@@ -25,7 +25,7 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED=OFF \
-        "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/libyaml/PSPBUILD
+++ b/libyaml/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=libyaml
 pkgver=0.2.5
-pkgrel=2
+pkgrel=3
 pkgdesc="LibYAML is a YAML parser and emitter library"
 arch=('mips')
 url="https://pyyaml.org/wiki/LibYAML"
@@ -17,7 +17,7 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
-        "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/libzip/PSPBUILD
+++ b/libzip/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=libzip
 pkgver=1.9.2
-pkgrel=2
+pkgrel=3
 pkgdesc="libzip is a C library for reading, creating, and modifying zip archives."
 arch=('mips')
 url="https://libzip.org/"
@@ -22,7 +22,7 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED=OFF \
-        -DBUILD_EXAMPLES=OFF -DBUILD_TOOLS=OFF -DBUILD_REGRESS=OFF -DBUILD_DOC=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DBUILD_EXAMPLES=OFF -DBUILD_TOOLS=OFF -DBUILD_REGRESS=OFF -DBUILD_DOC=OFF -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/lz4/PSPBUILD
+++ b/lz4/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=lz4
 pkgver=1.9.4
-pkgrel=1
+pkgrel=2
 pkgdesc="Extremely Fast Compression algorithm"
 arch=('mips')
 url="https://lz4.org/"
@@ -27,7 +27,7 @@ build() {
     cd build/psp
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
         -DBUILD_STATIC_LIBS=ON -DLZ4_POSITION_INDEPENDENT_LIB=OFF -DLZ4_BUILD_CLI=OFF -DLZ4_BUILD_LEGACY_LZ4C=OFF \
-        "${XTRA_OPTS[@]}" ../cmake || { exit 1; }
+        -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" ../cmake || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/mini18n/PSPBUILD
+++ b/mini18n/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=mini18n
 pkgver=0.2.1
-pkgrel=2
+pkgrel=3
 pkgdesc="mini18n is a translation library under GNU GPL."
 arch=('mips')
 url="https://github.com/bucanero/mini18n/"
@@ -19,7 +19,7 @@ prepare() {
 build() {
     cd "$pkgname/build"
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp \
-        -DBUILD_SHARED_LIBS=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DBUILD_SHARED_LIBS=OFF -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS mini18n-static || { exit 1; }
 }
 

--- a/minizip/PSPBUILD
+++ b/minizip/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=minizip
 pkgver=3.0.4
-pkgrel=3
+pkgrel=4
 pkgdesc="fork of the popular zip manipulation library found in the zlib distribution"
 arch=('mips')
 url="https://github.com/zlib-ng/minizip-ng"
@@ -25,7 +25,7 @@ build() {
   mkdir -p build
   cd build
   cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=/psp -DBUILD_SHARED_LIBS=OFF \
-      -DMZ_COMPAT=OFF -DMZ_LZMA=OFF -DMZ_OPENSSL=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
+      -DMZ_COMPAT=OFF -DMZ_LZMA=OFF -DMZ_OPENSSL=OFF "${XTRA_OPTS[@]}" -DCMAKE_BUILD_TYPE=Release .. || { exit 1; }
   make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/physfs/PSPBUILD
+++ b/physfs/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=physfs
 pkgver=3.2.0
-pkgrel=2
+pkgrel=3
 pkgdesc="PhysicsFS; a portable, flexible file i/o abstraction."
 arch=('mips')
 url="https://icculus.org/physfs/"
@@ -34,8 +34,8 @@ build() {
     mkdir pspbuild
     cd pspbuild
     psp-cmake .. -Wno-dev -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DPHYSFS_BUILD_TEST=Off \
-        -DPHYSFS_ARCHIVE_SLB=Off -DPHYSFS_BUILD_SHARED=Off -DPHYSFS_BUILD_DOCS=Off -DPHYSFS_ARCHIVE_ISO9660=Off
-    make
+        -DPHYSFS_ARCHIVE_SLB=Off -DPHYSFS_BUILD_SHARED=Off -DPHYSFS_BUILD_DOCS=Off -DPHYSFS_ARCHIVE_ISO9660=Off || { exit 1; }
+    make --quiet $MAKEFLAGS || { exit 1; }
 }
 
 package() {

--- a/sdl2-image/PSPBUILD
+++ b/sdl2-image/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=sdl2-image
 pkgver=2.6.3
-pkgrel=4
+pkgrel=5
 pkgdesc="a simple library to load images of various formats as SDL surfaces"
 arch=('mips')
 url="https://wiki.libsdl.org/SDL2_image/FrontPage"
@@ -28,7 +28,8 @@ build() {
     mkdir -p build && cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE="${PSPDEV}/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX=/psp \
         -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=OFF -DSDL2IMAGE_DEPS_SHARED=OFF \
-        -DSDL2IMAGE_INSTALL=ON -DSDL2IMAGE_SAMPLES=OFF -DSDL2IMAGE_BACKEND_STB=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DSDL2IMAGE_INSTALL=ON -DSDL2IMAGE_SAMPLES=OFF -DSDL2IMAGE_BACKEND_STB=OFF -DCMAKE_BUILD_TYPE=Release \
+        "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/sdl2-mixer/PSPBUILD
+++ b/sdl2-mixer/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=sdl2-mixer
 pkgver=2.6.3
-pkgrel=8
+pkgrel=9
 pkgdesc="an audio mixer library based on the SDL2 library"
 arch=('mips')
 url="https://wiki.libsdl.org/SDL2_mixer/FrontPage"
@@ -39,7 +39,7 @@ build() {
         -DSDL2MIXER_MIDI=OFF -DSDL2MIXER_VORBIS=VORBISFILE -DSDL2MIXER_VORBIS_VORBISFILE_SHARED=OFF \
         -DSDL2MIXER_MOD=ON -DSDL2MIXER_MOD_MODPLUG=ON -DSDL2MIXER_MOD_MODPLUG_SHARED=OFF \
         -DSDL2MIXER_MOD_XMP=OFF -DSDL2MIXER_MP3=ON -DSDL2MIXER_MP3_DRMP3=ON -DSDL2MIXER_MP3_MPG123=OFF \
-        .. "${XTRA_OPTS[@]}" || { exit 1; }
+        -DCMAKE_BUILD_TYPE=Release .. "${XTRA_OPTS[@]}" || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/sdl2-net/PSPBUILD
+++ b/sdl2-net/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=sdl2-net
 pkgver=2.2.0
-pkgrel=3
+pkgrel=4
 pkgdesc="a wrapper over TCP/IP sockets"
 arch=('mips')
 url="https://wiki.libsdl.org/SDL2_net/FrontPage"
@@ -29,7 +29,7 @@ build() {
     mkdir -p build && cd build
     cmake -DCMAKE_TOOLCHAIN_FILE="${PSPDEV}/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX=/psp \
         -DBUILD_SHARED_LIBS=OFF -DCMAKE_POSITION_INDEPENDENT_CODE=OFF -DSDL2NET_INSTALL=ON -DSDL2NET_SAMPLES=OFF \
-        .. "${XTRA_OPTS[@]}" || { exit 1; }
+        -DCMAKE_BUILD_TYPE=Release .. "${XTRA_OPTS[@]}" || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/sdl2-ttf/PSPBUILD
+++ b/sdl2-ttf/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=sdl2-ttf
 pkgver=2.20.2
-pkgrel=4
+pkgrel=5
 pkgdesc="a companion library to SDL2 for working with TrueType (tm) fonts"
 arch=('mips')
 url="https://wiki.libsdl.org/SDL2_ttf/FrontPage"
@@ -38,7 +38,8 @@ build() {
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE="${PSPDEV}/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX=/psp \
         -DSDL2TTF_HARFBUZZ=ON -DBUILD_SHARED_LIBS=OFF -DSDL2TTF_SAMPLES=OFF -DSDL2TTF_VENDORED=OFF \
-        -DCMAKE_POSITION_INDEPENDENT_CODE=OFF -DSDL2TTF_INSTALL=ON "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DCMAKE_POSITION_INDEPENDENT_CODE=OFF -DSDL2TTF_INSTALL=ON -DCMAKE_BUILD_TYPE=Release \
+        "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/squirrel/PSPBUILD
+++ b/squirrel/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=squirrel
 pkgver=3.1.0
-pkgrel=2
+pkgrel=3
 pkgdesc="Runtime libraries for the Squirrel programming language"
 arch=('mips')
 url="http://squirrel-lang.org/"
@@ -17,7 +17,7 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
-        "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/yaml-cpp/PSPBUILD
+++ b/yaml-cpp/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=yaml-cpp
 pkgver=0.8.0git
-pkgrel=2
+pkgrel=3
 pkgdesc=" A YAML parser and emitter in C++ "
 arch=('mips')
 url="https://github.com/jbeder/yaml-cpp"
@@ -24,7 +24,7 @@ build() {
     cd "yaml-cpp"
     mkdir -p build && cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE="${PSPDEV}/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX=/psp \
-        -DBUILD_SHARED_LIBS=OFF -DYAML_ENABLE_PIC=OFF "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DBUILD_SHARED_LIBS=OFF -DYAML_ENABLE_PIC=OFF -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 

--- a/zlib/PSPBUILD
+++ b/zlib/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=zlib
 pkgver=1.3.1
-pkgrel=4
+pkgrel=5
 pkgdesc="Compression library implementing the deflate compression method found in gzip and PKZIP"
 arch=('mips')
 url="https://www.zlib.net/"
@@ -21,7 +21,7 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=/psp -DBUILD_SHARED_LIBS=OFF -DZLIB_BUILD_EXAMPLES=OFF \
-        -DUNIX:BOOL=ON "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DUNIX:BOOL=ON -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet -j1 || { exit 1; }
 }
 

--- a/zziplib/PSPBUILD
+++ b/zziplib/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=zziplib
 pkgver=0.13.76
-pkgrel=2
+pkgrel=3
 pkgdesc="provides read access to zipped files in a zip-archive"
 arch=('mips')
 url="http://zziplib.sourceforge.net/"
@@ -17,7 +17,8 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
-        -DZZIPSDL=OFF -DZZIPBINS=OFF -DZZIPTEST=OFF -DZZIPDOCS=OFF -DGCOV_PATH=psp-gcov "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DZZIPSDL=OFF -DZZIPBINS=OFF -DZZIPTEST=OFF -DZZIPDOCS=OFF -DGCOV_PATH=psp-gcov -DCMAKE_BUILD_TYPE=Release \
+        "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 


### PR DESCRIPTION
This should speed up applications using these libraries and also lower  the size of both the libraries and the binaries that use them. We should make sure that all new libraries which are build using cmake build in release mode.