### PR TITLE
Downgrade OpenAL Soft version to fix compatibility

### DIFF
--- a/openal/PSPBUILD
+++ b/openal/PSPBUILD
@@ -1,5 +1,5 @@
 pkgname=openal
-pkgver=1.6.372
+pkgver=1.6.372.2
 pkgrel=1
 pkgdesc="a cross-platform 3D audio API"
 arch=('mips')
@@ -8,14 +8,14 @@ groups=('pspdev-default')
 url="https://openal-soft.org/"
 makedepends=()
 source=("https://github.com/illteteka/openal-soft-psp/archive/refs/tags/${pkgver}.tar.gz")
-sha256sums=('a185d9c1eea9782eaca8bf18a0b1af25bcadb9df147a06dafb31a4975510c97e')
+sha256sums=('2dd94abc457906203c03e87fd2c513077bde0d7344b377f09ec535f3b7cb0a91')
 
 prepare() {
     cd $pkgname-soft-psp-$pkgver
-    sed -i 's#@prefix@#${PSPDEV}/psp#' admin/pkgconfig/openal.pc.in
-    sed -i 's#@exec_prefix@#${prefix}#' admin/pkgconfig/openal.pc.in
-    sed -i 's#@libdir@#${prefix}/lib#' admin/pkgconfig/openal.pc.in
-    sed -i 's#@includedir@#${prefix}/include#' admin/pkgconfig/openal.pc.in
+    sed -i 's#@prefix@#${PSPDEV}/psp#' openal.pc.in
+    sed -i 's#@exec_prefix@#${prefix}#' openal.pc.in
+    sed -i 's#@libdir@#${prefix}/lib#' openal.pc.in
+    sed -i 's#@includedir@#${prefix}/include#' openal.pc.in
 }
 
 build() {
@@ -28,11 +28,11 @@ package () {
   mkdir -m 755 -p "$pkgdir/psp/lib" "$pkgdir/psp/include/AL" "$pkgdir/psp/include/OpenAL"
   install -m 644 libopenal.a "$pkgdir/psp/lib/libopenal.a"
   install -m 644 src/include/AL/*.h "$pkgdir/psp/include/AL/"
-  install -m 644 src/OpenAL32/include/*.h "$pkgdir/psp/include/OpenAL/"
+  install -m 644 src/OpenAL/include/*.h "$pkgdir/psp/include/OpenAL/"
 
   mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
   install -m 644 COPYING "$pkgdir/psp/share/licenses/$pkgname"
 
   mkdir -m 755 -p "$pkgdir/psp/lib/pkgconfig"
-  install -m 644 admin/pkgconfig/openal.pc.in "$pkgdir/psp/lib/pkgconfig/openal.pc"
+  install -m 644 openal.pc.in "$pkgdir/psp/lib/pkgconfig/openal.pc"
 }

--- a/openal/PSPBUILD
+++ b/openal/PSPBUILD
@@ -1,30 +1,35 @@
 pkgname=openal
-pkgver=1.6.372.2
-pkgrel=1
+pkgver=1.6.372
+pkgrel=2
 pkgdesc="a cross-platform 3D audio API"
 arch=('mips')
 license=('LGPL-2.0')
 groups=('pspdev-default')
 url="https://openal-soft.org/"
 makedepends=()
-source=("https://github.com/illteteka/openal-soft-psp/archive/refs/tags/${pkgver}.tar.gz")
+source=("https://github.com/illteteka/openal-soft-psp/archive/refs/tags/${pkgver}.${pkgrel}.tar.gz")
 sha256sums=('2dd94abc457906203c03e87fd2c513077bde0d7344b377f09ec535f3b7cb0a91')
 
 prepare() {
-    cd $pkgname-soft-psp-$pkgver
-    sed -i 's#@prefix@#${PSPDEV}/psp#' openal.pc.in
-    sed -i 's#@exec_prefix@#${prefix}#' openal.pc.in
-    sed -i 's#@libdir@#${prefix}/lib#' openal.pc.in
-    sed -i 's#@includedir@#${prefix}/include#' openal.pc.in
+  cd $pkgname-soft-psp-$pkgver.${pkgrel}
+  sed -i 's#@prefix@#${PSPDEV}/psp#' openal.pc.in
+  sed -i 's#@exec_prefix@#${prefix}#' openal.pc.in
+  sed -i 's#@libdir@#${prefix}/lib#' openal.pc.in
+  sed -i 's#@includedir@#${prefix}/include#' openal.pc.in
+
+  sed -i "s#@PKG_CONFIG_REQUIRES@##" openal.pc.in
+  sed -i "s#@PACKAGE_VERSION@#${pkgver}#" openal.pc.in
+  sed -i "s#@LIBNAME@#${pkgname}#" openal.pc.in
+  sed -i "s#@PKG_CONFIG_LIBS@##" openal.pc.in
 }
 
 build() {
-  cd $pkgname-soft-psp-$pkgver
+  cd $pkgname-soft-psp-$pkgver.${pkgrel}
   make --quiet $MAKEFLAGS || { exit 1; }
 }
 
 package () {
-  cd $pkgname-soft-psp-$pkgver
+  cd $pkgname-soft-psp-$pkgver.${pkgrel}
   mkdir -m 755 -p "$pkgdir/psp/lib" "$pkgdir/psp/include/AL" "$pkgdir/psp/include/OpenAL"
   install -m 644 libopenal.a "$pkgdir/psp/lib/libopenal.a"
   install -m 644 src/include/AL/*.h "$pkgdir/psp/include/AL/"

--- a/openal/PSPBUILD
+++ b/openal/PSPBUILD
@@ -12,6 +12,10 @@ sha256sums=('a185d9c1eea9782eaca8bf18a0b1af25bcadb9df147a06dafb31a4975510c97e')
 
 prepare() {
     cd $pkgname-soft-psp-$pkgver
+    sed -i 's#@prefix@#${PSPDEV}/psp#' admin/pkgconfig/openal.pc.in
+    sed -i 's#@exec_prefix@#${prefix}#' admin/pkgconfig/openal.pc.in
+    sed -i 's#@libdir@#${prefix}/lib#' admin/pkgconfig/openal.pc.in
+    sed -i 's#@includedir@#${prefix}/include#' admin/pkgconfig/openal.pc.in
 }
 
 build() {
@@ -28,4 +32,7 @@ package () {
 
   mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
   install -m 644 COPYING "$pkgdir/psp/share/licenses/$pkgname"
+
+  mkdir -m 755 -p "$pkgdir/psp/lib/pkgconfig"
+  install -m 644 admin/pkgconfig/openal.pc.in "$pkgdir/psp/lib/pkgconfig/openal.pc"
 }

--- a/openal/PSPBUILD
+++ b/openal/PSPBUILD
@@ -1,38 +1,31 @@
 pkgname=openal
-pkgver=1.23.1
-pkgrel=2
+pkgver=1.6.372
+pkgrel=1
 pkgdesc="a cross-platform 3D audio API"
 arch=('mips')
 license=('LGPL-2.0')
 groups=('pspdev-default')
 url="https://openal-soft.org/"
 makedepends=()
-source=("https://github.com/kcat/openal-soft/releases/download/${pkgver}/openal-soft-${pkgver}.tar.bz2")
-sha256sums=('796f4b89134c4e57270b7f0d755f0fa3435b90da437b745160a49bd41c845b21')
+source=("https://github.com/illteteka/openal-soft-psp/archive/refs/tags/${pkgver}.tar.gz")
+sha256sums=('a185d9c1eea9782eaca8bf18a0b1af25bcadb9df147a06dafb31a4975510c97e')
 
 prepare() {
-    cd $pkgname-soft-$pkgver
-    sed -i 's#@prefix@#${PSPDEV}/psp#' openal.pc.in
-    sed -i 's#@exec_prefix@#${prefix}#' openal.pc.in
-    sed -i 's#@libdir@#${prefix}/lib#' openal.pc.in
-    sed -i 's#@includedir@#${prefix}/include#' openal.pc.in
+    cd $pkgname-soft-psp-$pkgver
 }
 
 build() {
-  cd $pkgname-soft-$pkgver
-  mkdir -p build
-  cd build
-  cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=/psp -DCMAKE_BUILD_TYPE=Release \
-        -DALSOFT_UTILS=OFF -DALSOFT_EXAMPLES=OFF -DLIBTYPE=STATIC "${XTRA_OPTS[@]}" .. || { exit 1; }
+  cd $pkgname-soft-psp-$pkgver
   make --quiet $MAKEFLAGS || { exit 1; }
 }
 
 package () {
-  cd "$pkgname-soft-$pkgver/build"
-  make --quiet DESTDIR=$pkgdir $MAKEFLAGS install
-  cd ..
+  cd $pkgname-soft-psp-$pkgver
+  mkdir -m 755 -p "$pkgdir/psp/lib" "$pkgdir/psp/include/AL" "$pkgdir/psp/include/OpenAL"
+  install -m 644 libopenal.a "$pkgdir/psp/lib/libopenal.a"
+  install -m 644 src/include/AL/*.h "$pkgdir/psp/include/AL/"
+  install -m 644 src/OpenAL32/include/*.h "$pkgdir/psp/include/OpenAL/"
 
   mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
   install -m 644 COPYING "$pkgdir/psp/share/licenses/$pkgname"
-  install -m 644 BSD-3Clause "$pkgdir/psp/share/licenses/$pkgname"
 }


### PR DESCRIPTION
This is an older port of OpenAL Soft from around 2009. The version of OpenAL in this repo (1.23.1) does not compile for the PSP. If anyone else wants to test this, I have an example program to test it with: https://github.com/illteteka/openal-soft-psp/tree/main/examples/pitch