### PR TITLE
Fix libmodplug.pc

### DIFF
--- a/libmodplug/PSPBUILD
+++ b/libmodplug/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=libmodplug
 pkgver=0.8.8.5
-pkgrel=2
+pkgrel=3
 pkgdesc="libmodplug - the library which was part of the Modplug-xmms project"
 arch=('mips')
 url="http://modplug-xmms.sf.net/"
@@ -16,6 +16,14 @@ source=(
 sha256sums=(
 "SKIP"
 )
+
+prepare() {
+    cd libmodplug
+    sed -i 's#@prefix@#${PSPDEV}/psp#' libmodplug.pc.in
+    sed -i 's#@exec_prefix@#${prefix}#' libmodplug.pc.in
+    sed -i 's#@libdir@#${prefix}/lib#' libmodplug.pc.in
+    sed -i '/configure_file/{s/)/ @ONLY)/;}' CMakeLists.txt
+}
 
 build() {
     cd libmodplug


### PR DESCRIPTION
It had full paths in it.

The sed in the CMakeLists.txt was needed because CMake was overwriting prefix, exec_prefix and libdir with full paths regardless of if they were in the file with @s around them otherwise.