### PR TITLE
Fix license names

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,7 @@ For new contributions to be merged, the PSPBUILDs in them should meet the follow
   - PSPBUILDs which use a git repository as source should use a specific tag or commit.
   - ``pkgname`` should not contain capital letters or special characters other than ``-``.
   - ``groups`` should be set if to ``pspdev-default`` unless the package conflicts with an existing package.
+  - Be specific in the license field and follow the [spdx](https://spdx.org/licenses/) formatting for the license name.
 - For existing packages:
   - Either the ``pkgver`` or ``rel`` has been changed.
 - For all PSPBUILDs:

--- a/angelscript/PSPBUILD
+++ b/angelscript/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=angelscript
 pkgver=2.28.2
-pkgrel=3
+pkgrel=4
 pkgdesc="A game-oriented interpreted compiled scripting language library"
 arch=('mips')
 url="http://angelcode.com/angelscript/"
-license=('ZLIB')
+license=('Zlib')
 groups=('pspdev-default')
 depends=()
 makedepends=()

--- a/argtable2/PSPBUILD
+++ b/argtable2/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=argtable2
 pkgver=13
-pkgrel=4
+pkgrel=5
 pkgdesc="Argtable is an ANSI C library for parsing GNU style command line options with a minimum of fuss"
 arch=('mips')
 url="http://argtable.sourceforge.net/"
-license=('GPL2')
+license=('GPL-2.0-only')
 groups=('pspdev-default')
 depends=()
 makedepends=()

--- a/dumb/PSPBUILD
+++ b/dumb/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=dumb
 pkgver=2.0.3
-pkgrel=3
+pkgrel=4
 pkgdesc="Dynamic Universal Music Bibliotheque - DUMB - Module/tracker based music format parser and player library"
 arch=('mips')
 url="https://github.com/kode54/dumb"
-license=('GPL2')
+license=('custom')
 groups=('pspdev-default')
 depends=()
 makedepends=()

--- a/flac/PSPBUILD
+++ b/flac/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=flac
 pkgver=1.4.3
-pkgrel=1
+pkgrel=2
 pkgdesc="Free Lossless Audio Codec"
 arch=('mips')
 url="https://xiph.org/flac/"
-license=('GFDL-1.2 AND GPL-2.0 AND LGPL-2.1 AND BSD-3-Clause')
+license=('BSD-3-Clause')
 groups=('pspdev-default')
 depends=('libogg')
 makedepends=()
@@ -44,6 +44,6 @@ package() {
     rm -rf "${pkgdir}"/psp/lib/lib{FLAC,FLAC++}.la
 
     mkdir -m 755 -p "${pkgdir}/psp/share/licenses/${pkgname}"
-    install -m 644 COPYING.* "${pkgdir}/psp/share/licenses/${pkgname}"
+    install -m 644 COPYING.Xiph "${pkgdir}/psp/share/licenses/${pkgname}"
 }
 

--- a/flatbuffers/PSPBUILD
+++ b/flatbuffers/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=flatbuffers
 pkgver=24.3.25
-pkgrel=1
+pkgrel=2
 pkgdesc="Memory Efficient Serialization Library"
 arch=('mips')
 url="https://flatbuffers.dev"
-license=('Apache-2.0 license')
+license=('Apache-2.0')
 groups=('pspdev-default')
 source=("https://github.com/google/${pkgname}/archive/refs/tags/v${pkgver}.tar.gz")
 sha256sums=('4157c5cacdb59737c5d627e47ac26b140e9ee28b1102f812b36068aab728c1ed')

--- a/freetype2/PSPBUILD
+++ b/freetype2/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=freetype2
 pkgver=2.11.0
-pkgrel=5
+pkgrel=6
 pkgdesc="a freely available software library to render fonts"
 arch=('mips')
 url="https://www.freetype.org/"
-license=('custom:Freetype' 'GPL2')
+license=('FTL OR GPL-2.0-or-later')
 groups=('pspdev-default')
 depends=('zlib' 'bzip2' 'libpng')
 makedepends=()

--- a/jsoncpp/PSPBUILD
+++ b/jsoncpp/PSPBUILD
@@ -1,9 +1,9 @@
 pkgname=jsoncpp
 pkgver=1.9.5
-pkgrel=3
+pkgrel=4
 pkgdesc="a C++ library for interacting with JSON"
 arch=('mips')
-license=('unlicense')
+license=('Unlicense')
 groups=('pspdev-default')
 url="https://github.com/open-source-parsers/jsoncpp"
 makedepends=()

--- a/kubridge/PSPBUILD
+++ b/kubridge/PSPBUILD
@@ -1,9 +1,9 @@
 pkgname=kubridge
 pkgver=20240427
-pkgrel=2
+pkgrel=3
 pkgdesc="a bridging library to provide Kernel functions for PSPs in User Mode"
 arch=('mips')
-license=('GPL2')
+license=('GPL-2.0-only')
 groups=('pspdev-default')
 url="https://github.com/pspdev/kubridge"
 makedepends=()

--- a/libbulletml/PSPBUILD
+++ b/libbulletml/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=libbulletml
 pkgver=0.0.5
-pkgrel=3
+pkgrel=4
 pkgdesc="Bullet Markup Language for PSP"
 arch=('mips')
 url="https://www.asahi-net.or.jp/~cs8k-cyu/bulletml/index_e.html"
-license=('BSD')
+license=('BSD-3-Clause')
 groups=('pspdev-default')
 depends=()
 makedepends=()

--- a/libeigen/PSPBUILD
+++ b/libeigen/PSPBUILD
@@ -1,9 +1,9 @@
 pkgname=libeigen
 pkgver=3.4.0
-pkgrel=2
+pkgrel=3
 url="http://eigen.tuxfamily.org"
 source=("https://gitlab.com/libeigen/eigen/-/archive/3.4.0/eigen-$pkgver.tar.gz")
-license=('BSD')
+license=('MPL-2.0 AND BSD-3-Clause AND LGPL-2.1-only AND LGPL-2.1-or-later')
 groups=('pspdev-default')
 depends=()
 makedepends=()

--- a/libintrafont/PSPBUILD
+++ b/libintrafont/PSPBUILD
@@ -1,9 +1,9 @@
 pkgname=libintrafont
 pkgver=4.0
-pkgrel=2
+pkgrel=3
 pkgdesc="A bitmap font library using the PSP's internal fonts (firmware pgf and bwfon files)"
 arch=('mips')
-license=('cc-by-sa-3.0')
+license=('CC-BY-SA-3.0')
 groups=('pspdev-default')
 url="https://github.com/pspdev/libintrafont"
 makedepends=()

--- a/libmad/PSPBUILD
+++ b/libmad/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=libmad
 pkgver=0.15.1
-pkgrel=4
+pkgrel=5
 pkgdesc="MPEG audio decoder library for PSP"
 arch=('mips')
 url="https://www.underbit.com/products/mad"
-license=('GPL2')
+license=('GPL-2.0-only')
 groups=('pspdev-default')
 depends=()
 makedepends=()

--- a/libmikmod/PSPBUILD
+++ b/libmikmod/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=libmikmod
 pkgver=3.3.11.1
-pkgrel=6
+pkgrel=7
 pkgdesc="a portable sound library capable of playing samples as well as module files"
 arch=('mips')
 url="http://mikmod.sourceforge.net/"
-license=('GPL2.1')
+license=('LGPL-2.1-only')
 groups=('pspdev-default')
 depends=()
 makedepends=()
@@ -35,7 +35,6 @@ package () {
     cd ..
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname/"
-    install -m 644 COPYING.LIB "$pkgdir/psp/share/licenses/$pkgname/"
     install -m 644 COPYING.LESSER "$pkgdir/psp/share/licenses/$pkgname/"
     install -m 644 AUTHORS "$pkgdir/psp/share/licenses/$pkgname/"
 }

--- a/libmodplug/PSPBUILD
+++ b/libmodplug/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=libmodplug
 pkgver=0.8.8.5
-pkgrel=3
+pkgrel=4
 pkgdesc="libmodplug - the library which was part of the Modplug-xmms project"
 arch=('mips')
 url="http://modplug-xmms.sf.net/"
-license=('public domain')
+license=('custom:Public-Domain')
 groups=('pspdev-default')
 depends=()
 makedepends=()

--- a/libogg/PSPBUILD
+++ b/libogg/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=libogg
 pkgver=1.3.5
-pkgrel=4
+pkgrel=5
 pkgdesc="library for the multimedia container format, and the native file and stream format ogg"
 arch=('mips')
 url="https://www.xiph.org/ogg/"
-license=('BSD')
+license=('BSD-3-Clause')
 groups=('pspdev-default')
 depends=()
 makedepends=()

--- a/libpng/PSPBUILD
+++ b/libpng/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=libpng
 pkgver=1.6.43
-pkgrel=7
+pkgrel=8
 pkgdesc="libpng is the official PNG reference library"
 arch=('mips')
 url="http://libpng.org/pub/png/libpng.html"
-license=('ZLIB')
+license=('libpng-2.0')
 groups=('pspdev-default')
 depends=('zlib')
 makedepends=()

--- a/libun7zip/PSPBUILD
+++ b/libun7zip/PSPBUILD
@@ -1,9 +1,9 @@
 pkgname=libun7zip
 pkgver=19.00
-pkgrel=3
+pkgrel=4
 pkgdesc="A library that provides 7-Zip (.7z) archive handling and extraction"
 arch=('mips')
-license=('Apache-2.0 license')
+license=('Apache-2.0')
 groups=('pspdev-default')
 url="https://github.com/bucanero/libun7zip"
 makedepends=()

--- a/libvorbis/PSPBUILD
+++ b/libvorbis/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=libvorbis
 pkgver=1.3.7
-pkgrel=4
+pkgrel=5
 pkgdesc="Vorbis audio compression reference implementation"
 arch=('mips')
 url="https://gitlab.xiph.org/xiph/vorbis"
-license=('BSD')
+license=('BSD-3-Clause')
 groups=('pspdev-default')
 depends=('libogg')
 makedepends=()

--- a/libxmp/PSPBUILD
+++ b/libxmp/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=libxmp
 pkgver=4.5.0
-pkgrel=4
+pkgrel=5
 pkgdesc="Libxmp is a library that renders module files to PCM data"
 arch=('mips')
 url="https://github.com/libxmp/libxmp"
-license=('GPL2')
+license=('LGPL-2.1-only')
 groups=('pspdev-default')
 depends=()
 makedepends=()
@@ -36,5 +36,6 @@ package() {
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
     install -m 644 docs/COPYING.LIB "$pkgdir/psp/share/licenses/$pkgname"
+    install -m 644 docs/CREDITS "$pkgdir/psp/share/licenses/$pkgname"
 }
 

--- a/libzip/PSPBUILD
+++ b/libzip/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=libzip
 pkgver=1.9.2
-pkgrel=3
+pkgrel=4
 pkgdesc="libzip is a C library for reading, creating, and modifying zip archives."
 arch=('mips')
 url="https://libzip.org/"
-license=('3-clause BSD license')
+license=('BSD-3-Clause')
 groups=('pspdev-default')
 depends=('zlib' 'bzip2')
 makedepends=()

--- a/mbedtls/PSPBUILD
+++ b/mbedtls/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=mbedtls
 pkgver=2.16.12
-pkgrel=2
+pkgrel=3
 pkgdesc="Secure Socket Layer library"
 arch=('mips')
 url="https://www.trustedfirmware.org/projects/mbed-tls/"
-license=('Apache 2.0 license')
+license=('Apache-2.0')
 groups=('pspdev-default')
 depends=()
 optdepends=()

--- a/mini18n/PSPBUILD
+++ b/mini18n/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=mini18n
 pkgver=0.2.1
-pkgrel=3
+pkgrel=4
 pkgdesc="mini18n is a translation library under GNU GPL."
 arch=('mips')
 url="https://github.com/bucanero/mini18n/"
-license=('GPL 2.0')
+license=('GPL-2.0-only')
 groups=('pspdev-default')
 depends=()
 makedepends=()

--- a/minizip/PSPBUILD
+++ b/minizip/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=minizip
 pkgver=3.0.4
-pkgrel=4
+pkgrel=5
 pkgdesc="fork of the popular zip manipulation library found in the zlib distribution"
 arch=('mips')
 url="https://github.com/zlib-ng/minizip-ng"
-license=('zlib')
+license=('Zlib')
 groups=('pspdev-default')
 depends=('zlib' 'bzip2')
 makedepends=()

--- a/mpg123/PSPBUILD
+++ b/mpg123/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=mpg123
 pkgver=1.32.10
-pkgrel=1
+pkgrel=2
 pkgdesc="MPEG audio decoder library"
 arch=('mips')
 url="http://www.mpg123.org/"
-license=('LGPL-2.1')
+license=('LGPL-2.1-only')
 groups=('pspdev-default')
 depends=()
 makedepends=()

--- a/openal/PSPBUILD
+++ b/openal/PSPBUILD
@@ -1,13 +1,13 @@
 pkgname=openal
-pkgver=1.6.372
-pkgrel=3
+pkgver=1.6.372.2
+pkgrel=1
 pkgdesc="a cross-platform 3D audio API"
 arch=('mips')
 license=('LGPL-2.0-only')
 groups=('pspdev-default')
 url="https://openal-soft.org/"
 makedepends=()
-source=("https://github.com/illteteka/openal-soft-psp/archive/refs/tags/${pkgver}.${pkgrel}.tar.gz")
+source=("https://github.com/illteteka/openal-soft-psp/archive/refs/tags/${pkgver}.tar.gz")
 sha256sums=('2dd94abc457906203c03e87fd2c513077bde0d7344b377f09ec535f3b7cb0a91')
 
 prepare() {

--- a/openal/PSPBUILD
+++ b/openal/PSPBUILD
@@ -11,7 +11,7 @@ source=("https://github.com/illteteka/openal-soft-psp/archive/refs/tags/${pkgver
 sha256sums=('2dd94abc457906203c03e87fd2c513077bde0d7344b377f09ec535f3b7cb0a91')
 
 prepare() {
-  cd $pkgname-soft-psp-$pkgver.${pkgrel}
+  cd $pkgname-soft-psp-$pkgver
   sed -i 's#@prefix@#${PSPDEV}/psp#' openal.pc.in
   sed -i 's#@exec_prefix@#${prefix}#' openal.pc.in
   sed -i 's#@libdir@#${prefix}/lib#' openal.pc.in
@@ -24,12 +24,12 @@ prepare() {
 }
 
 build() {
-  cd $pkgname-soft-psp-$pkgver.${pkgrel}
+  cd $pkgname-soft-psp-$pkgver
   make --quiet $MAKEFLAGS || { exit 1; }
 }
 
 package () {
-  cd $pkgname-soft-psp-$pkgver.${pkgrel}
+  cd $pkgname-soft-psp-$pkgver
   mkdir -m 755 -p "$pkgdir/psp/lib" "$pkgdir/psp/include/AL" "$pkgdir/psp/include/OpenAL"
   install -m 644 libopenal.a "$pkgdir/psp/lib/libopenal.a"
   install -m 644 src/include/AL/*.h "$pkgdir/psp/include/AL/"

--- a/openal/PSPBUILD
+++ b/openal/PSPBUILD
@@ -1,9 +1,9 @@
 pkgname=openal
 pkgver=1.6.372
-pkgrel=2
+pkgrel=3
 pkgdesc="a cross-platform 3D audio API"
 arch=('mips')
-license=('LGPL-2.0')
+license=('LGPL-2.0-only')
 groups=('pspdev-default')
 url="https://openal-soft.org/"
 makedepends=()

--- a/opentri/PSPBUILD
+++ b/opentri/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=opentri
 pkgver=r7.95b040d
-pkgrel=5
+pkgrel=6
 pkgdesc="openTRI is a game engine for the PSP"
 arch=('mips')
 url="https://github.com/fjtrujy/openTRI"
-license=('GPL2')
+license=('GPL-2.0-only')
 groups=('pspdev-default')
 depends=('zlib' 'freetype2')
 makedepends=()

--- a/physfs/PSPBUILD
+++ b/physfs/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=physfs
 pkgver=3.2.0
-pkgrel=3
+pkgrel=4
 pkgdesc="PhysicsFS; a portable, flexible file i/o abstraction."
 arch=('mips')
 url="https://icculus.org/physfs/"

--- a/polarssl/PSPBUILD
+++ b/polarssl/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=polarssl
 pkgver=1.3.9
-pkgrel=3
+pkgrel=4
 pkgdesc="Secure Socket Layer library"
 arch=('mips')
 url="https://www.trustedfirmware.org/projects/mbed-tls/"
-license=('GPL2')
+license=('GPL-2.0-only')
 groups=('pspdev-default')
 depends=()
 makedepends=()

--- a/pspgl/PSPBUILD
+++ b/pspgl/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=pspgl
 pkgver=r12
-pkgrel=4
+pkgrel=5
 pkgdesc="OpenGL-ESish library for PSP"
 arch=('mips')
 url="https://github.com/pspdev/pspgl"
-license=('BSD')
+license=('BSD-3-Clause')
 groups=('pspdev-default')
 depends=()
 makedepends=()

--- a/pspirkeyb/PSPBUILD
+++ b/pspirkeyb/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=pspirkeyb
 pkgver=r1
-pkgrel=3
+pkgrel=4
 pkgdesc="a library for using IRDA keyboards with Playstation Portable"
 arch=('mips')
 url="https://github.com/pspdev/pspirkeyb"
-license=('LGPL2.1')
+license=('LGPL-2.1-only')
 groups=('pspdev-default')
 depends=()
 makedepends=()

--- a/sdl-gfx/PSPBUILD
+++ b/sdl-gfx/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=sdl-gfx
 pkgver=2.0.26
-pkgrel=3
+pkgrel=4
 pkgdesc="SDL graphics drawing primitives and other support functions"
 arch=('mips')
 url="https://www.ferzkopp.net/wordpress/2016/01/02/sdl_gfx-sdl2_gfx/"
-license=('ZLIB')
+license=('Zlib')
 groups=('pspdev-default')
 depends=('sdl' 'freetype2')
 makedepends=()

--- a/sdl-image/PSPBUILD
+++ b/sdl-image/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=sdl-image
 pkgver=1.2.13
-pkgrel=5
+pkgrel=6
 pkgdesc="a simple library to load images of various formats as SDL2 surfaces"
 arch=('mips')
 url="https://www.libsdl.org/projects/old/SDL_image/release-1.2.html"
-license=('ZLIB')
+license=('Zlib')
 groups=('pspdev-default')
 depends=('sdl' 'libpng' 'jpeg')
 makedepends=()

--- a/sdl-mixer/PSPBUILD
+++ b/sdl-mixer/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=sdl-mixer
 pkgver=1.2.14
-pkgrel=6
+pkgrel=7
 pkgdesc="an audio mixer library based on the SDL library"
 arch=('mips')
 url="https://www.libsdl.org/projects/old/SDL_mixer/release-1.2.html"
-license=('ZLIB')
+license=('Zlib')
 groups=('pspdev-default')
 depends=('sdl' 'libmikmod' 'libogg' 'libvorbis')
 makedepends=()

--- a/sdl-net/PSPBUILD
+++ b/sdl-net/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=sdl-net
 pkgver=1.2.9
-pkgrel=2
+pkgrel=3
 pkgdesc="a wrapper over TCP/IP sockets"
 arch=('mips')
 url="https://www.libsdl.org/projects/old/SDL_net/release-1.2.html"
-license=('ZLIB')
+license=('Zlib')
 groups=('pspdev-default')
 depends=('sdl')
 makedepends=()

--- a/sdl-ttf/PSPBUILD
+++ b/sdl-ttf/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=sdl-ttf
 pkgver=2.0.11
-pkgrel=5
+pkgrel=6
 pkgdesc="a companion library to SDL for working with TrueType (tm) fonts"
 arch=('mips')
 url="https://www.libsdl.org/projects/old/SDL_ttf/release-1.2.html"
-license=('ZLIB')
+license=('Zlib')
 groups=('pspdev-default')
 depends=('sdl' 'freetype2')
 makedepends=()

--- a/sdl/PSPBUILD
+++ b/sdl/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=sdl
 pkgver=1.2.15
-pkgrel=5
+pkgrel=6
 pkgdesc="a library designed to provide low level access to audio, input, and graphics hardware"
 arch=('mips')
 url="https://www.libsdl.org/download-1.2.php"
-license=('LGPL-2.1')
+license=('LGPL-2.1-only')
 groups=('pspdev-default')
 depends=('pspirkeyb')
 makedepends=()

--- a/sdl2-gfx/PSPBUILD
+++ b/sdl2-gfx/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=sdl2-gfx
 pkgver=1.0.4
-pkgrel=3
+pkgrel=4
 pkgdesc="SDL2 graphics drawing primitives and other support functions"
 arch=('mips')
 url="http://www.ferzkopp.net/wordpress/2016/01/02/sdl_gfx-sdl2_gfx/"
-license=('ZLIB')
+license=('Zlib')
 groups=('pspdev-default')
 depends=('sdl2')
 makedepends=()

--- a/sdl2-image/PSPBUILD
+++ b/sdl2-image/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=sdl2-image
 pkgver=2.6.3
-pkgrel=5
+pkgrel=6
 pkgdesc="a simple library to load images of various formats as SDL surfaces"
 arch=('mips')
 url="https://wiki.libsdl.org/SDL2_image/FrontPage"
-license=('ZLIB')
+license=('Zlib')
 groups=('pspdev-default')
 depends=('sdl2' 'libpng' 'jpeg')
 makedepends=()

--- a/sdl2-mixer/PSPBUILD
+++ b/sdl2-mixer/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=sdl2-mixer
 pkgver=2.8.0
-pkgrel=1
+pkgrel=2
 pkgdesc="an audio mixer library based on the SDL2 library"
 arch=('mips')
 url="https://wiki.libsdl.org/SDL2_mixer/FrontPage"
-license=('ZLIB')
+license=('Zlib')
 groups=('pspdev-default')
 depends=('sdl2' 'libmodplug' 'libvorbis' 'libogg')
 makedepends=()

--- a/sdl2-net/PSPBUILD
+++ b/sdl2-net/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=sdl2-net
 pkgver=2.2.0
-pkgrel=4
+pkgrel=5
 pkgdesc="a wrapper over TCP/IP sockets"
 arch=('mips')
 url="https://wiki.libsdl.org/SDL2_net/FrontPage"
-license=('ZLIB')
+license=('Zlib')
 groups=('pspdev-default')
 depends=('sdl2')
 makedepends=()

--- a/sdl2-ttf/PSPBUILD
+++ b/sdl2-ttf/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=sdl2-ttf
 pkgver=2.20.2
-pkgrel=5
+pkgrel=6
 pkgdesc="a companion library to SDL2 for working with TrueType (tm) fonts"
 arch=('mips')
 url="https://wiki.libsdl.org/SDL2_ttf/FrontPage"
-license=('ZLIB')
+license=('Zlib')
 groups=('pspdev-default')
 depends=('sdl2' 'harfbuzz')
 makedepends=()

--- a/sdl2/PSPBUILD
+++ b/sdl2/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=sdl2
 pkgver=2.30.10
-pkgrel=1
+pkgrel=2
 pkgdesc="a library designed to provide low level access to audio, input, and graphics hardware"
 arch=('mips')
 url="https://wiki.libsdl.org/SDL2/FrontPage"
-license=('ZLIB')
+license=('Zlib')
 groups=('pspdev-default')
 depends=('libpspvram' 'pspgl')
 makedepends=()

--- a/sdl3/PSPBUILD
+++ b/sdl3/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=sdl3
 pkgver=3.2.0
-pkgrel=1
+pkgrel=2
 pkgdesc="a library designed to provide low level access to audio, input, and graphics hardware"
 arch=('mips')
 url="https://wiki.libsdl.org/SDL3/FrontPage"
-license=('ZLIB')
+license=('Zlib')
 groups=('pspdev-default')
 depends=('libpspvram' 'pspgl')
 makedepends=()

--- a/smpeg/PSPBUILD
+++ b/smpeg/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=smpeg
 pkgver=0.4.5
-pkgrel=3
+pkgrel=4
 pkgdesc="a free MPEG1 video player library with sound support"
 arch=('mips')
 url="https://github.com/fungos/smpeg-psp/"
-license=('LGPL2')
+license=('LGPL-2.0-only')
 groups=('pspdev-default')
 depends=('sdl')
 makedepends=()

--- a/sqlite/PSPBUILD
+++ b/sqlite/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=sqlite
 pkgver=3.7.4
-pkgrel=4
+pkgrel=5
 pkgdesc="SQLite is a C-language library that implements a small, fast, self-contained, high-reliability, full-featured, SQL database engine"
 arch=('mips')
 url="https://www.sqlite.org/"
-license=('custom:Public Domain')
+license=('custom:Public-Domain')
 groups=('pspdev-default')
 depends=()
 optdepends=()

--- a/stb/PSPBUILD
+++ b/stb/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=stb
 pkgver=20241015git
-pkgrel=1
+pkgrel=2
 pkgdesc="a collection of single-file public domain libraries for C/C++"
 arch=('any')
 url="https://github.com/nothings/stb"
-license=('Public-Domain or MIT')
+license=('custom:Public-Domain or MIT')
 groups=('pspdev-default')
 depends=()
 makedepends=()

--- a/theora/PSPBUILD
+++ b/theora/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=theora
 pkgver=1.2.0git
-pkgrel=3
+pkgrel=4
 pkgdesc="Standard encoder and decoder library for the Theora video compression format"
 arch=('mips')
 url="https://www.theora.org/"
-license=('BSD')
+license=('BSD-3-Clause')
 groups=('pspdev-default')
 depends=('libogg')
 makedepends=()

--- a/tinygettext/PSPBUILD
+++ b/tinygettext/PSPBUILD
@@ -1,9 +1,9 @@
 pkgname=tinygettext
 pkgver=20240715
-pkgrel=1
+pkgrel=2
 pkgdesc="a simple gettext replacement that works directly on .po files"
 arch=('mips')
-license=('zlib')
+license=('Zlib')
 groups=('pspdev-default')
 url="https://github.com/tinygettext/tinygettext"
 depends=('sdl2')

--- a/tremor/PSPBUILD
+++ b/tremor/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=tremor
 pkgver=1.2.1git
-pkgrel=2
+pkgrel=3
 pkgdesc="Integer-only, fully Ogg Vorbis compliant software decoder library"
 arch=('mips')
 url="https://wiki.xiph.org/Tremor"
-license=('BSD')
+license=('BSD-3-Clause')
 groups=('pspdev-default')
 depends=('libogg')
 makedepends=()

--- a/wolfssl/PSPBUILD
+++ b/wolfssl/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=wolfssl
 pkgver=5.7.0
-pkgrel=3
+pkgrel=4
 pkgdesc="The wolfSSL library is a small, fast, portable implementation of TLS/SSL for embedded devices to the cloud. wolfSSL supports up to TLS 1.3!"
 arch=('mips')
 url="www.wolfssl.com"
-license=('GPL2')
+license=('GPL-2.0-only')
 groups=('pspdev-default')
 depends=()
 makedepends=()

--- a/zlib/PSPBUILD
+++ b/zlib/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=zlib
 pkgver=1.3.1
-pkgrel=5
+pkgrel=6
 pkgdesc="Compression library implementing the deflate compression method found in gzip and PKZIP"
 arch=('mips')
 url="https://www.zlib.net/"
-license=('ZLIB')
+license=('Zlib')
 groups=('pspdev-default')
 depends=()
 makedepends=()

--- a/zziplib/PSPBUILD
+++ b/zziplib/PSPBUILD
@@ -1,10 +1,10 @@
 pkgname=zziplib
 pkgver=0.13.76
-pkgrel=3
+pkgrel=4
 pkgdesc="provides read access to zipped files in a zip-archive"
 arch=('mips')
 url="http://zziplib.sourceforge.net/"
-license=('ZLIB')
+license=('Zlib')
 groups=('pspdev-default')
 depends=('zlib')
 makedepends=()


### PR DESCRIPTION
This switches the entire repo to the [spdx standard](https://spdx.org/licenses/) for package names, which is also done in Arch Linux for example. Some licenses were incorrect before. I've added sources to the commits which change the license in a couple of cases. Otherwise the bundled license should be clear enough.