### PR TITLE
Link to package source directly

### DIFF
--- a/make-repo-html.sh
+++ b/make-repo-html.sh
@@ -12,11 +12,11 @@ set -e
 
 # Set global variables
 GITHUB_REPOSITORY_OWNER="${GITHUB_REPOSITORY_OWNER:-pspdev}"
-GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-pspdev/pspdev}"
+GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-pspdev/psp-packages}"
 INDEX_TABLE_CONTENT=""
 
 # Build the html pages
-for PSPBUILD in $(find . -name "PSPBUILD" | sort); do
+for PSPBUILD in $(find . -maxdepth 2 -name "PSPBUILD"  | sort); do
   		# Make sure optional variables are from current PSPBUILD
   		unset groups
     		unset license

--- a/package.html
+++ b/package.html
@@ -28,6 +28,6 @@
 
         <p><a href="index.html">Back to index</a></p>
 
-        <p>Source on <a href="https://github.com/${GITHUB_REPOSITORY}/">GitHub</a></p>
+        <p>Source on <a href="https://github.com/${GITHUB_REPOSITORY}/blob/master/${pkgname}/PSPBUILD">GitHub</a></p>
     </body>
 </html>


### PR DESCRIPTION
The link on the page of a package did not go directly to the package itself. This fixes that.

There are also some minor changes which made it work on my machine. Not setting the maxdepth makes the find command slower if you have build packages and can result in permission warnings. The default for GITHUB_REPOSITORY was just set wrong.