### PR TITLE
Fix mbedtls build

### DIFF
--- a/mbedtls/PSPBUILD
+++ b/mbedtls/PSPBUILD
@@ -10,21 +10,21 @@ depends=()
 optdepends=()
 makedepends=()
 source=(
-    "git+https://github.com/Mbed-TLS/mbedtls.git#commit=cf4667126010c665341f9e50ef691b7ef8294188"
+    "https://src.fedoraproject.org/repo/pkgs/mbedtls/mbedtls-2.16.12.tar.gz/sha512/8d96d8cd906cc0999134320e4e1f550631426d166eab5da6e65469ee7286093810fcc6ac4bd5500ee55972d159f8bef7f9e53245f7f0eec72f72c35265b4313b/${pkgname}-${pkgver}.tar.gz"
     "${pkgname}-${pkgver}-PSP.patch"
 )
 sha256sums=(
-    "SKIP"
+    "294871ab1864a65d0b74325e9219d5bcd6e91c34a3c59270c357bb9ae4d5c393"
     "SKIP"
 )
 
 prepare() {
-    cd "${pkgname}"
+    cd "${pkgname}-${pkgver}"
     patch -p1 < ../${pkgname}-${pkgver}-PSP.patch || { exit 1; }
 }
 
 build() {
-    cd "${pkgname}"
+    cd "${pkgname}-${pkgver}"
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE="${PSPDEV}/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX="${pkgdir}/psp" \
@@ -34,7 +34,7 @@ build() {
 }
 
 package() {
-    cd "${pkgname}/build"
+    cd "${pkgname}-${pkgver}/build"
     make --quiet $MAKEFLAGS install
     cd ..
     mkdir -m 755 -p "${pkgdir}/psp/share/licenses/${pkgname}"

--- a/mbedtls/PSPBUILD
+++ b/mbedtls/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=mbedtls
 pkgver=2.16.12
-pkgrel=3
+pkgrel=4
 pkgdesc="Secure Socket Layer library"
 arch=('mips')
 url="https://www.trustedfirmware.org/projects/mbed-tls/"
@@ -10,34 +10,34 @@ depends=()
 optdepends=()
 makedepends=()
 source=(
-    "http://sources.buildroot.net/mbedtls/${pkgname}-${pkgver}.tar.gz"
+    "git+https://github.com/Mbed-TLS/mbedtls.git#commit=cf4667126010c665341f9e50ef691b7ef8294188"
     "${pkgname}-${pkgver}-PSP.patch"
 )
 sha256sums=(
-    "294871ab1864a65d0b74325e9219d5bcd6e91c34a3c59270c357bb9ae4d5c393"
+    "SKIP"
     "SKIP"
 )
 
 prepare() {
-    cd "${pkgname}-${pkgver}"
+    cd "${pkgname}"
     patch -p1 < ../${pkgname}-${pkgver}-PSP.patch || { exit 1; }
 }
 
 build() {
-    cd "$pkgname-$pkgver"
+    cd "${pkgname}"
     mkdir -p build
     cd build
-    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp \
+    cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE="${PSPDEV}/psp/share/pspdev.cmake" -DCMAKE_INSTALL_PREFIX="${pkgdir}/psp" \
         -DCMAKE_C_FLAGS="-Wno-error=incompatible-pointer-types" \
         -DCMAKE_BUILD_TYPE=Release -DENABLE_TESTING=FALSE -DENABLE_PROGRAMS=FALSE "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 
 package() {
-    cd "$pkgname-$pkgver/build"
+    cd "${pkgname}/build"
     make --quiet $MAKEFLAGS install
     cd ..
-    mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
-    install -m 644 LICENSE "$pkgdir/psp/share/licenses/$pkgname"
-    install -m 644 apache-2.0.txt "$pkgdir/psp/share/licenses/$pkgname"
+    mkdir -m 755 -p "${pkgdir}/psp/share/licenses/${pkgname}"
+    install -m 644 LICENSE "${pkgdir}/psp/share/licenses/${pkgname}"
+    install -m 644 apache-2.0.txt "${pkgdir}/psp/share/licenses/${pkgname}"
 }


### PR DESCRIPTION
The download url no longer goes anywhere useful, so I changed the PSPBUILD to use git and pull the commit that corresponds with the release we were already building. I also did some minor consistency fixes in the PSPBUILD.