### PR TITLE
Fix 429 errors because of pulling too many patches

### DIFF
--- a/mpg123/17.patch
+++ b/mpg123/17.patch
@@ -1,0 +1,36 @@
+From 324d307f08a4041c1ce56a917a9f4514a43c9105 Mon Sep 17 00:00:00 2001
+From: Wouter Wijsman <wouter@gridscale.io>
+Date: Tue, 14 Jan 2025 17:56:14 +0100
+Subject: [PATCH] CMake: Only build shared libraries with position independent
+ code
+
+---
+ ports/cmake/src/compat/CMakeLists.txt | 12 +++++++++---
+ 1 file changed, 9 insertions(+), 3 deletions(-)
+
+diff --git a/ports/cmake/src/compat/CMakeLists.txt b/ports/cmake/src/compat/CMakeLists.txt
+index a98eccca..c4b2ec11 100644
+--- a/ports/cmake/src/compat/CMakeLists.txt
++++ b/ports/cmake/src/compat/CMakeLists.txt
+@@ -2,12 +2,18 @@ set(TARGET compat)
+ add_library(${TARGET} OBJECT
+     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../src/compat/compat.c"
+     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../src/compat/compat_str.c")
+-set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
++if(BUILD_SHARED_LIBS)
++    set_target_properties(${TARGET} PROPERTIES POSITION_INDEPENDENT_CODE ON)
++endif()
+ 
+ add_library(${TARGET}_dl OBJECT
+     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../src/compat/compat_dl.c")
+-set_target_properties(${TARGET}_dl PROPERTIES POSITION_INDEPENDENT_CODE ON)
++if(BUILD_SHARED_LIBS)
++    set_target_properties(${TARGET}_dl PROPERTIES POSITION_INDEPENDENT_CODE ON)
++endif()
+ 
+ add_library(${TARGET}_str OBJECT
+     "${CMAKE_CURRENT_SOURCE_DIR}/../../../../src/compat/compat_str.c")
+-set_target_properties(${TARGET}_str PROPERTIES POSITION_INDEPENDENT_CODE ON)
++if(BUILD_SHARED_LIBS)
++    set_target_properties(${TARGET}_str PROPERTIES POSITION_INDEPENDENT_CODE ON)
++endif()

--- a/mpg123/18.patch
+++ b/mpg123/18.patch
@@ -1,0 +1,22 @@
+From b67f4213948dd83298a57ab1dfc8e355b2cf7e8f Mon Sep 17 00:00:00 2001
+From: Wouter Wijsman <wwijsman@live.nl>
+Date: Fri, 17 Jan 2025 22:10:35 +0100
+Subject: [PATCH] compat: do not rely on signal.h on PSP
+
+---
+ src/compat/compat.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/compat/compat.c b/src/compat/compat.c
+index 09983ca4..78900128 100644
+--- a/src/compat/compat.c
++++ b/src/compat/compat.c
+@@ -512,7 +512,7 @@ size_t INT123_unintr_fwrite(const void *ptr, size_t size, size_t nmemb, FILE *st
+ }
+ 
+ #ifndef NO_CATCHSIGNAL
+-#if (!defined(WIN32) || defined (__CYGWIN__)) && defined(HAVE_SIGNAL_H)
++#if (!defined(WIN32) || defined (__CYGWIN__)) && !defined(__PSP__) && defined(HAVE_SIGNAL_H)
+ void (*INT123_catchsignal(int signum, void(*handler)(int)))(int)
+ {
+ 	struct sigaction new_sa;

--- a/mpg123/PSPBUILD
+++ b/mpg123/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=mpg123
 pkgver=1.32.10
-pkgrel=2
+pkgrel=3
 pkgdesc="MPEG audio decoder library"
 arch=('mips')
 url="http://www.mpg123.org/"
@@ -11,13 +11,13 @@ makedepends=()
 optdepends=()
 source=(
     "https://sourceforge.net/projects/mpg123/files/mpg123/${pkgver}/mpg123-${pkgver}.tar.bz2"
-    "https://github.com/madebr/mpg123/pull/17.patch"
-    "https://github.com/madebr/mpg123/pull/18.patch"
+    "17.patch"
+    "18.patch"
 )
 sha256sums=(
     "87b2c17fe0c979d3ef38eeceff6362b35b28ac8589fbf1854b5be75c9ab6557c"
-    "SKIP"
-    "SKIP"
+    "23fc836581a77589e9bb077f271c04f8d2b43b598173facacff63667f36babbd"
+    "e8c3e301fe1cdd05a2d21a8fc4c5634f5df00b208b1a64475a81874c8abd10eb"
 )
 
 prepare() {


### PR DESCRIPTION
For some reason GitHub starts rate limiting if you download 2 patch files from PRs, so I added the 2 patches for mpg123 to the repo.