### PR TITLE
Add libpspmath

### DIFF
--- a/libpspmath/PSPBUILD
+++ b/libpspmath/PSPBUILD
@@ -28,5 +28,5 @@ package() {
     make --quiet $MAKEFLAGS install
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
-    install -m 644 "$pkgdir/psp/share/licenses/pspsdk/LICENSE" "$pkgdir/psp/share/licenses/$pkgname"
+    install -m 644 "${PSPDEV}/psp/share/licenses/pspsdk/LICENSE" "$pkgdir/psp/share/licenses/$pkgname"
 }

--- a/libpspmath/PSPBUILD
+++ b/libpspmath/PSPBUILD
@@ -25,7 +25,10 @@ build() {
 
 package() {
     cd "$pkgname"
-    make --quiet $MAKEFLAGS install
+        mkdir -m 775 -p "$pkgdir/psp/sdk/lib"
+        install -m 644 libpspmath.a "$pkgdir/psp/sdk/lib/"
+        mkdir -m 775 -p "$pkgdir/psp/sdk/include"
+	install -m 644 pspmath.h "$pkgdir/psp/sdk/include/"
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
     install -m 644 "${PSPDEV}/psp/share/licenses/pspsdk/LICENSE" "$pkgdir/psp/share/licenses/$pkgname"

--- a/libpspmath/PSPBUILD
+++ b/libpspmath/PSPBUILD
@@ -1,0 +1,33 @@
+pkgname=libpspmath
+pkgver=r4.eb44107
+pkgrel=1
+pkgdesc="Import of mrmrice's libpspmath vfpu library for psp homebrew"
+arch=('mips')
+url="https://github.com/tufty/libpspmath"
+license=('BSD-3-Clause')
+groups=('pspdev-default')
+depends=()
+makedepends=()
+optdepends=()
+source=("git+https://github.com/tufty/libpspmath.git#commit=eb44107538fa84bab299b5d7dcf71df64a674da3")
+sha256sums=('SKIP')
+
+pkgver() {
+    cd "$pkgname"
+    # Set the revision of the repo as version
+    printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+    cd "$pkgname"
+    make --quiet $MAKEFLAGS || { exit 1; }
+}
+
+package() {
+    cd "$pkgname/build"
+    make --quiet $MAKEFLAGS install
+
+    cd ..
+    mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
+    install -m 644 "$pkgdir/psp/share/licenses/pspsdk/LICENSE" "$pkgdir/psp/share/licenses/$pkgname"
+}

--- a/libpspmath/PSPBUILD
+++ b/libpspmath/PSPBUILD
@@ -24,10 +24,9 @@ build() {
 }
 
 package() {
-    cd "$pkgname/build"
+    cd "$pkgname"
     make --quiet $MAKEFLAGS install
 
-    cd ..
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
     install -m 644 "$pkgdir/psp/share/licenses/pspsdk/LICENSE" "$pkgdir/psp/share/licenses/$pkgname"
 }


### PR DESCRIPTION
Straightforward addition of `libpspmath` to the pacman repo. I think originally there was some concern over licensing since the only living standalone repository doesn't bundle it, though MrMr[ICE] deliberately referenced the PSPSDK license header in `pspmath.h` and was a well-known figure head at the time (especially for the VFPU docs), so I don't think it's ambiguous to say its sharing the license with the PSPSDK as BSD 3-Clause. 