### PR TITLE
Exclude luasocket from build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -13,7 +13,7 @@
 
 set -e
 
-BLACKLIST="lua51|lua52|lua53|pocketpy"
+BLACKLIST="lua51|lua52|lua53|pocketpy|luasocket"
 
 doinstall=""
 if [ "$1" == "--install" ]; then


### PR DESCRIPTION
It relies on a version of lua which is not being build by the build.sh script.