### PR TITLE
Make argtable2 build with gcc 15.1.1

### DIFF
--- a/argtable2/PSPBUILD
+++ b/argtable2/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=argtable2
 pkgver=13
-pkgrel=5
+pkgrel=6
 pkgdesc="Argtable is an ANSI C library for parsing GNU style command line options with a minimum of fuss"
 arch=('mips')
 url="http://argtable.sourceforge.net/"
@@ -24,7 +24,7 @@ build() {
     mkdir -p build
     cd build
     cmake -Wno-dev -DCMAKE_TOOLCHAIN_FILE=$PSPDEV/psp/share/pspdev.cmake -DCMAKE_INSTALL_PREFIX=${pkgdir}/psp -DBUILD_SHARED_LIBS=OFF \
-        -DCMAKE_BUILD_TYPE=Release "${XTRA_OPTS[@]}" .. || { exit 1; }
+        -DCMAKE_BUILD_TYPE=Release -DCMAKE_C_FLAGS="-D__GNU_LIBRARY__" "${XTRA_OPTS[@]}" .. || { exit 1; }
     make --quiet $MAKEFLAGS || { exit 1; }
 }
 


### PR DESCRIPTION
I forgot about this one, but argtable2 wasn't building anymore. This small change fixes it for now.