### PR TITLE
Remove unnecessary rm commands

### DIFF
--- a/expat/PSPBUILD
+++ b/expat/PSPBUILD
@@ -36,9 +36,5 @@ package() {
 
     mkdir -m 755 -p "$pkgdir/psp/share/licenses/$pkgname"
     install -m 644 ../COPYING "$pkgdir/psp/share/licenses/$pkgname"
-
-    # Remove the binary we can't use
-    rm -rf "${pkgdir}/psp/share/man"
-    rm -rf "${pkgdir}/psp/bin"
 }
 


### PR DESCRIPTION
The binaries are not generated due to -DEXPAT_BUILD_TOOLS=OFF, same for docs. It's better not to play with rm rf :)