### PR TITLE
sdl3: fix audio and upgrade to 3.2.18

### DIFF
--- a/sdl3/PSPBUILD
+++ b/sdl3/PSPBUILD
@@ -1,5 +1,5 @@
 pkgname=sdl3
-pkgver=3.2.16
+pkgver=3.2.18
 pkgrel=1
 pkgdesc="a library designed to provide low level access to audio, input, and graphics hardware"
 arch=('mips')
@@ -10,14 +10,23 @@ depends=('libpspvram' 'pspgl')
 makedepends=()
 optdepends=()
 provides=()
-source=("https://github.com/libsdl-org/SDL/releases/download/release-${pkgver}/SDL3-${pkgver}.tar.gz")
-sha256sums=("6340e58879b2d15830c8460d2f589a385c444d1faa2a4828a9626c7322562be8")
+source=(
+    "https://github.com/libsdl-org/SDL/releases/download/release-${pkgver}/SDL3-${pkgver}.tar.gz"
+    "sdl3-audio-fix.patch"
+)
+sha256sums=(
+    "1a775bde924397a8e0c08bfda198926c17be859d0288ad0dec1dea1b2ee04f8f"
+    "SKIP"
+)
 
 prepare() {
     cd "${srcdir}/SDL3-${pkgver}"
     sed -i 's#@SDL_PKGCONFIG_PREFIX@#${PSPDEV}/psp#' cmake/sdl3.pc.in
     sed -i 's#@LIBDIR_FOR_PKG_CONFIG@#${prefix}/lib#' cmake/sdl3.pc.in
     sed -i 's#@INCLUDEDIR_FOR_PKG_CONFIG@#${prefix}\/include#' cmake/sdl3.pc.in
+
+    # This fix will be in 3.2.20, until then we need a patch to make audio work
+    patch -p1 < ../sdl3-audio-fix.patch
 }
 
 build() {

--- a/sdl3/sdl3-audio-fix.patch
+++ b/sdl3/sdl3-audio-fix.patch
@@ -1,0 +1,22 @@
+From ba40bc86ee1e4f3e04447239ac1c7fbda769cc21 Mon Sep 17 00:00:00 2001
+From: Wouter Wijsman <wwijsman@live.nl>
+Date: Wed, 30 Jul 2025 21:06:13 +0200
+Subject: [PATCH] psp: fix audio not playing
+
+---
+ src/audio/psp/SDL_pspaudio.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/audio/psp/SDL_pspaudio.c b/src/audio/psp/SDL_pspaudio.c
+index 18546e88fc7ac..1b095e97f2fd2 100644
+--- a/src/audio/psp/SDL_pspaudio.c
++++ b/src/audio/psp/SDL_pspaudio.c
+@@ -114,7 +114,7 @@ static bool PSPAUDIO_PlayDevice(SDL_AudioDevice *device, const Uint8 *buffer, in
+     } else {
+         rc = sceAudioOutputPannedBlocking(device->hidden->channel, PSP_AUDIO_VOLUME_MAX, PSP_AUDIO_VOLUME_MAX, (void *) buffer);
+     }
+-    return (rc == 0);
++    return (rc >= 0);
+ }
+ 
+ static bool PSPAUDIO_WaitDevice(SDL_AudioDevice *device)


### PR DESCRIPTION
Right now audio is broken in SDL3, so I included the patch I submitted upstream. The next release should no longer need it.