### PR TITLE
Fix Node version warnings in GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-latest
     container: python:3-alpine
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Generate build list
         id: set-matrix
         run: |
@@ -36,7 +36,7 @@ jobs:
         packages: ${{ fromJson(needs.prepare_jobs.outputs.build_list) }}
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Build packages
       run: |
         adduser -D -h /build -s /bin/bash build
@@ -52,7 +52,7 @@ jobs:
       run: |
         export PACKAGE=`echo ${{ matrix.packages }} | awk '{print $NF}'`
         echo "PACKAGE=$PACKAGE" >> $GITHUB_ENV
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@v7
       with:
         name: artifact-${{ env.PACKAGE }}
         path: ${{ env.PACKAGE }}/*.pkg.tar.gz
@@ -64,11 +64,11 @@ jobs:
     container: ghcr.io/pspdev/pspsdk:latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
     - name: Download artifacts
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
     - name: Create repo files
       run: |
         chown -R $(id -nu):$(id -ng) .
@@ -82,7 +82,7 @@ jobs:
         mv pspdev.files.tar.gz pspdev.files
         tar -cvf ../repo.tar ./*
     - name: Upload repo artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: github-pages
         path: repo.tar
@@ -97,10 +97,10 @@ jobs:
 
     steps:
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5
 
   docker-layer:
     if: contains(github.ref,'refs/heads/master')
@@ -108,22 +108,22 @@ jobs:
     runs-on: ubuntu-latest
   
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
 
     - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
+      uses: docker/setup-qemu-action@v4
       
     - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@v4
       
     - name: Login to Github registry
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
         registry: ghcr.io
     
-    - uses: docker/build-push-action@v5
+    - uses: docker/build-push-action@v7
       with:
         push: true
         tags: ghcr.io/${{ github.repository }}:latest
@@ -135,7 +135,7 @@ jobs:
         export DISPATCH_ACTION="$(echo run_build)"
         echo "NEW_DISPATCH_ACTION=$DISPATCH_ACTION" >> $GITHUB_ENV
     - name: Repository Dispatch to pspdev
-      uses: peter-evans/repository-dispatch@v3
+      uses: peter-evans/repository-dispatch@v4
       with:
         repository: ${{ github.repository_owner }}/pspdev
         token: ${{ secrets.DISPATCH_TOKEN }}


### PR DESCRIPTION
In the changelogs I could not find any changes that should prevent this from just working without other changes. We will find out.