### PR TITLE
Update SDL2 and SDL3 libraries to latest versions

### DIFF
--- a/sdl2-image/PSPBUILD
+++ b/sdl2-image/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=sdl2-image
-pkgver=2.8.6
-pkgrel=8
+pkgver=2.8.12
+pkgrel=1
 pkgdesc="A simple library to load images of various formats as SDL surfaces"
 arch=(any)
 url="https://wiki.libsdl.org/SDL2_image/FrontPage"
@@ -13,7 +13,7 @@ source=(
     "https://github.com/libsdl-org/SDL_image/releases/download/release-${pkgver}/SDL2_image-${pkgver}.tar.gz"
 )
 sha256sums=(
-    "b71903ef444e6011b7d7751f2cf1bc90994810e199818f2706be62d45b10a848"
+    "393f5efb50536ec13ca4f4affb69cc9966d3c3f969e6c5e701faddf9f9785381"
 )
 prepare() {
     cd "${srcdir}/SDL2_image-${pkgver}"

--- a/sdl2-mixer/PSPBUILD
+++ b/sdl2-mixer/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=sdl2-mixer
-pkgver=2.8.0
-pkgrel=4
+pkgver=2.8.2
+pkgrel=1
 pkgdesc="An audio mixer library based on the SDL2 library"
 arch=(any)
 url="https://wiki.libsdl.org/SDL2_mixer/FrontPage"
@@ -16,7 +16,7 @@ source=(
     "https://pspdev.github.io/resources/test.ogg"
 )
 sha256sums=(
-    "1cfb34c87b26dbdbc7afd68c4f545c0116ab5f90bbfecc5aebe2a9cb4bb31549"
+    "938dff531d00ace2296557a6599abe6f34599e2f34f0a4a08a397e2ccac8b8f7"
     "SKIP"
     "SKIP"
     "b728bb95b6018ba0bb5675d614f2e25d056d04c6b471f4f080623c570f905e01"

--- a/sdl2/PSPBUILD
+++ b/sdl2/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=sdl2
-pkgver=2.32.8
-pkgrel=3
+pkgver=2.32.10
+pkgrel=1
 pkgdesc="A library designed to provide low level access to audio, input, and graphics hardware"
 arch=(any)
 url="https://wiki.libsdl.org/SDL2/FrontPage"
@@ -16,7 +16,7 @@ source=(
     "main.c.sample"
 )
 sha256sums=(
-    "0ca83e9c9b31e18288c7ec811108e58bac1f1bb5ec6577ad386830eac51c787e"
+    "5f5993c530f084535c65a6879e9b26ad441169b3e25d789d83287040a9ca5165"
     "SKIP"
     "SKIP"
 )

--- a/sdl3-image/PSPBUILD
+++ b/sdl3-image/PSPBUILD
@@ -1,6 +1,6 @@
 pkgname=sdl3-image
-pkgver=3.2.4
-pkgrel=3
+pkgver=3.4.4
+pkgrel=1
 pkgdesc="A simple library to load images of various formats as SDL surfaces"
 arch=(any)
 url="https://wiki.libsdl.org/SDL3_image/FrontPage"
@@ -13,7 +13,7 @@ source=(
     "https://github.com/libsdl-org/SDL_image/releases/download/release-${pkgver}/SDL3_image-${pkgver}.tar.gz"
 )
 sha256sums=(
-    "a725bd6d04261fdda0dd8d950659e1dc15a8065d025275ef460d32ae7dcfc182"
+    "29751304a13d25ac513f24305fa25b06a6edd9607718c90129b8350d35fc5573"
 )
 prepare() {
     cd "${srcdir}/SDL3_image-${pkgver}"

--- a/sdl3-mixer/PSPBUILD
+++ b/sdl3-mixer/PSPBUILD
@@ -1,5 +1,5 @@
 pkgname=sdl3-mixer
-pkgver=3.2.0
+pkgver=3.2.4
 pkgrel=1
 pkgdesc="An audio mixer library based on the SDL3 library"
 arch=(any)
@@ -13,7 +13,7 @@ source=(
     "https://github.com/libsdl-org/SDL_mixer/releases/download/release-${pkgver}/SDL3_mixer-${pkgver}.tar.gz"
 )
 sha256sums=(
-    "1f86fae7226d58f2ad210ca4d9e06488db722230032803423d83bad6d35fc395"
+    "182a07c745375e113dc740d43964ff21b0be29f29f59876c4dbc4db3d32f6901"
 )
 
 prepare() {

--- a/sdl3/PSPBUILD
+++ b/sdl3/PSPBUILD
@@ -1,5 +1,5 @@
 pkgname=sdl3
-pkgver=3.4.2
+pkgver=3.4.10
 pkgrel=1
 pkgdesc="A library designed to provide low level access to audio, input, and graphics hardware"
 arch=(any)
@@ -14,7 +14,7 @@ source=(
     "https://github.com/libsdl-org/SDL/releases/download/release-${pkgver}/SDL3-${pkgver}.tar.gz"
 )
 sha256sums=(
-    "ef39a2e3f9a8a78296c40da701967dd1b0d0d6e267e483863ce70f8a03b4050c"
+    "12b34280415ec8418c864408b93d008a20a6530687ee613d60bfbd20411f2785"
 )
 
 prepare() {


### PR DESCRIPTION
We were falling behind a little bit. There are no specific PSP fixes in the new versions.